### PR TITLE
Allow Constraints to use BTree or Gin Indices

### DIFF
--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -239,7 +239,6 @@ SELECT * FROM cypher('cypher_match',
  $$MATCH (n  {string_key: "wrong value"}) RETURN n $$)
 AS (n agtype);
 
-
 SELECT * FROM cypher('cypher_match', $$
     MATCH (n {string_key: "test", int_key: 1, float_key: 3.14, map_key: {key: "value"}, list_key: [1, 2, 3]})
     RETURN n $$)

--- a/regress/sql/index.sql
+++ b/regress/sql/index.sql
@@ -253,7 +253,6 @@ SELECT COUNT(*) FROM cypher('cypher_index', $$
     RETURN a
 $$) as (n agtype);
 
-
 --
 -- General Cleanup
 --


### PR DESCRIPTION
We cannot remove the qual for one until the optimizer phase, which will require much more work to do. For now add a qual of both styles to allow the optimizer to pick the index it has