### PR TITLE
Fixed issue with indirection in sublinks

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -1001,6 +1001,29 @@ $$) as (n agtype);
  {"id": 281474976710662, "label": "", "properties": {"i": 1, "j": 2, "k": 3}}::vertex
 (1 row)
 
+--here
+select * from cypher('cypher_match', $$
+ match (v2)
+ where exists((v2 {i: 1}))
+ return v2
+$$) as (v agtype);
+                                          v                                           
+--------------------------------------------------------------------------------------
+ {"id": 281474976710662, "label": "", "properties": {"i": 1, "j": 2, "k": 3}}::vertex
+ {"id": 281474976710663, "label": "", "properties": {"i": 1, "j": 3}}::vertex
+(2 rows)
+
+select * from cypher('cypher_match', $$
+        match (v)-[e]->(v2)
+        with v2, count(*) as cnt
+        where cnt > 1
+        return v2
+$$) as (v agtype);
+                                     v                                     
+---------------------------------------------------------------------------
+ {"id": 281474976710661, "label": "", "properties": {"name": "T"}}::vertex
+(1 row)
+
 --
 -- Clean up
 --

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -510,6 +510,20 @@ SELECT * FROM cypher('cypher_match', $$
     RETURN n
 $$) as (n agtype);
 
+--here
+select * from cypher('cypher_match', $$
+ match (v2)
+ where exists((v2 {i: 1}))
+ return v2
+$$) as (v agtype);
+
+select * from cypher('cypher_match', $$
+        match (v)-[e]->(v2)
+        with v2, count(*) as cnt
+        where cnt > 1
+        return v2
+$$) as (v agtype);
+
 --
 -- Clean up
 --

--- a/src/backend/parser/cypher_parse_node.c
+++ b/src/backend/parser/cypher_parse_node.c
@@ -61,6 +61,7 @@ cypher_parsestate *make_cypher_parsestate(cypher_parsestate *parent_cpstate)
         cpstate->graph_name = parent_cpstate->graph_name;
         cpstate->graph_oid = parent_cpstate->graph_oid;
         cpstate->params = parent_cpstate->params;
+        cpstate->inSubLink = parent_cpstate->inSubLink;
     }
 
     return cpstate;

--- a/src/include/parser/cypher_parse_node.h
+++ b/src/include/parser/cypher_parse_node.h
@@ -46,6 +46,7 @@ typedef struct cypher_parsestate
      */
     bool exprHasAgg;
     bool p_opt_match;
+    bool inSubLink;
 } cypher_parsestate;
 
 typedef struct errpos_ecb_state


### PR DESCRIPTION
Cannot directly reference a ParseNamespaceItem in a sublink, added logic to bypass sublinks in that case.