### PR TITLE
[ Typecasting ]Added Text array to agtype

### DIFF
--- a/age--1.1.0.sql
+++ b/age--1.1.0.sql
@@ -3198,6 +3198,8 @@ AS 'MODULE_PATHNAME';
 CREATE CAST (agtype AS text)
 WITH FUNCTION ag_catalog.agtype_to_text(agtype);
 
+-- text -> agtype (explicit)
+
 CREATE FUNCTION ag_catalog.text_to_agtype(text)
 RETURNS agtype
 LANGUAGE c
@@ -3208,6 +3210,17 @@ AS 'MODULE_PATHNAME';
 
 CREATE CAST (text AS agtype)
 WITH FUNCTION ag_catalog.text_to_agtype(text);
+
+CREATE FUNCTION ag_catalog.text_array_to_agtype(text[])
+RETURNS agtype
+LANGUAGE c
+IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME';
+
+CREATE CAST (text[] AS agtype)
+WITH FUNCTION ag_catalog.text_array_to_agtype(text[]);
 
 
 -- agtype -> boolean (implicit)

--- a/regress/expected/catalog.out
+++ b/regress/expected/catalog.out
@@ -408,8 +408,8 @@ SELECT create_graph_if_not_exists('new_g');
 SELECT * FROM ag_catalog.ag_graph;
  graphid | name  | namespace 
 ---------+-------+-----------
-   17697 | g     | g
-   17737 | new_g | new_g
+   17699 | g     | g
+   17739 | new_g | new_g
 (2 rows)
 
 -- dropping the graph

--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -6284,6 +6284,15 @@ SELECT 'This is a string'::text::agtype;
 (1 row)
 
 --
+-- text array to agtype typecasting
+--
+SELECT * FROM text_array_to_agtype(ARRAY [ '(408)-589-5846','(408)-589-5555' ]);
+         text_array_to_agtype         
+--------------------------------------
+ ["(408)-589-5846", "(408)-589-5555"]
+(1 row)
+
+--
 -- Cleanup
 --
 SELECT * FROM drop_graph('chained', true);

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -2469,6 +2469,12 @@ SELECT * from cypher('list', $$RETURN labels("string")$$) as (Labels agtype);
 SELECT text_to_agtype('test');
 SELECT 'This is a string'::text::agtype;
 
+--
+-- text array to agtype typecasting
+--
+
+SELECT * FROM text_array_to_agtype(ARRAY [ '(408)-589-5846','(408)-589-5555' ]);
+
 
 
 

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -2817,6 +2817,62 @@ Datum text_to_agtype(PG_FUNCTION_ARGS)
     return string_to_agtype(text_to_cstring(PG_GETARG_TEXT_PP(0)));
 }
 
+PG_FUNCTION_INFO_V1(text_array_to_agtype);
+/*
+ * Cast text to agtpe.
+ */
+Datum text_array_to_agtype(PG_FUNCTION_ARGS)
+{
+
+    ArrayType *keys = PG_GETARG_ARRAYTYPE_P(0);
+    int i;
+    Datum *key_datums;
+    bool *key_nulls;
+    int elem_count;
+    agtype_in_state edges_result;
+
+    deconstruct_array(keys, TEXTOID, -1, false, 'i', &key_datums, &key_nulls,
+                      &elem_count);
+
+    /*initialize our arrays*/
+    MemSet(&edges_result, 0, sizeof(agtype_in_state));
+
+    /*start our array */
+    edges_result.res = push_agtype_value(&edges_result.parse_state,
+                                         WAGT_BEGIN_ARRAY, NULL);
+    
+    /*Get each Element from the array and add it into agtype array */
+    for (i = 0; i < elem_count; i++)
+    {
+        agtype_value strVal;
+
+        if (key_nulls[i])
+        {
+            continue;
+        }
+        
+
+        strVal.type = AGTV_STRING;
+        strVal.val.string.val = VARDATA(key_datums[i]);
+        strVal.val.string.len = VARSIZE(key_datums[i]) - VARHDRSZ;
+
+        edges_result.res = push_agtype_value(&edges_result.parse_state,
+                                             WAGT_ELEM, &strVal);
+
+    }
+
+    /* close our agtype array */
+    edges_result.res = push_agtype_value(&edges_result.parse_state,
+                                         WAGT_END_ARRAY, NULL);
+
+    /* make it an array */
+    edges_result.res->type = AGTV_ARRAY;
+
+    PG_RETURN_POINTER(agtype_value_to_agtype(edges_result.res));
+
+
+}
+
 PG_FUNCTION_INFO_V1(bool_to_agtype);
 
 /*


### PR DESCRIPTION
Added the function to convert text array to agtype array.
Added testcase also
Changed catalog testcases also

Useage:
`SELECT * FROM text_array_to_agtype(ARRAY [ 'Test1','Test2' ]);`

```
Output:
 text_array_to_agtype
----------------------
 ["Test1", "Test2"]
(1 row)

```

