### PR TITLE
Refactor Agtype builtin functions

### DIFF
--- a/age--1.1.0.sql
+++ b/age--1.1.0.sql
@@ -3380,7 +3380,7 @@ RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION ag_catalog.age_eq_tilde(agtype, agtype)
+CREATE FUNCTION ag_catalog.agtype_eq_tilde(agtype, agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
@@ -3436,388 +3436,388 @@ AS 'MODULE_PATHNAME';
 --
 -- Scalar Functions
 --
-CREATE FUNCTION ag_catalog.age_id(agtype)
+CREATE FUNCTION ag_catalog.id(agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_id';
 
-CREATE FUNCTION ag_catalog.age_start_id(agtype)
+CREATE FUNCTION ag_catalog.start_id(agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_start_id';
 
-CREATE FUNCTION ag_catalog.age_end_id(agtype)
+CREATE FUNCTION ag_catalog.end_id(agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_end_id';
 
-CREATE FUNCTION ag_catalog.age_head(agtype)
+CREATE FUNCTION ag_catalog.head(agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_head';
 
-CREATE FUNCTION ag_catalog.age_last(agtype)
+CREATE FUNCTION ag_catalog.last(agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_last';
 
-CREATE FUNCTION ag_catalog.age_properties(agtype)
+CREATE FUNCTION ag_catalog.properties(agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_properties';
 
-CREATE FUNCTION ag_catalog.age_startnode(agtype, agtype)
+CREATE FUNCTION ag_catalog.startnode(agtype, agtype)
 RETURNS agtype
 LANGUAGE c
 STABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_startnode';
 
-CREATE FUNCTION ag_catalog.age_endnode(agtype, agtype)
+CREATE FUNCTION ag_catalog.endnode(agtype, agtype)
 RETURNS agtype
 LANGUAGE c
 STABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_endnode';
 
-CREATE FUNCTION ag_catalog.age_length(agtype)
+CREATE FUNCTION ag_catalog.length(agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_length';
 
-CREATE FUNCTION ag_catalog.age_toboolean(variadic "any")
+CREATE FUNCTION ag_catalog.toboolean(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_toboolean';
 
-CREATE FUNCTION ag_catalog.age_tofloat(variadic "any")
+CREATE FUNCTION ag_catalog.tofloat(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_tofloat';
 
-CREATE FUNCTION ag_catalog.age_tointeger(variadic "any")
+CREATE FUNCTION ag_catalog.tointeger(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_tointeger';
 
-CREATE FUNCTION ag_catalog.age_tostring(variadic "any")
+CREATE FUNCTION ag_catalog.tostring(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_tostring';
 
-CREATE FUNCTION ag_catalog.age_size(variadic "any")
+CREATE FUNCTION ag_catalog.size(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_size';
 
-CREATE FUNCTION ag_catalog.age_type(agtype)
+CREATE FUNCTION ag_catalog.type(agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_type';
 
-CREATE FUNCTION ag_catalog.age_label(agtype)
+CREATE FUNCTION ag_catalog.label(agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_label';
 
 --
 -- String functions
 --
-CREATE FUNCTION ag_catalog.age_reverse(variadic "any")
+CREATE FUNCTION ag_catalog.reverse(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_reverse';
 
-CREATE FUNCTION ag_catalog.age_toupper(variadic "any")
+CREATE FUNCTION ag_catalog.toupper(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_toupper';
 
-CREATE FUNCTION ag_catalog.age_tolower(variadic "any")
+CREATE FUNCTION ag_catalog.tolower(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_tolower';
 
-CREATE FUNCTION ag_catalog.age_ltrim(variadic "any")
+CREATE FUNCTION ag_catalog.ltrim(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_ltrim';
 
-CREATE FUNCTION ag_catalog.age_rtrim(variadic "any")
+CREATE FUNCTION ag_catalog.rtrim(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_rtrim';
 
-CREATE FUNCTION ag_catalog.age_trim(variadic "any")
+CREATE FUNCTION ag_catalog.trim(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_trim';
 
-CREATE FUNCTION ag_catalog.age_right(variadic "any")
+CREATE FUNCTION ag_catalog.right(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_right';
 
-CREATE FUNCTION ag_catalog.age_left(variadic "any")
+CREATE FUNCTION ag_catalog.left(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_left';
 
-CREATE FUNCTION ag_catalog.age_substring(variadic "any")
+CREATE FUNCTION ag_catalog.substring(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_substring';
 
-CREATE FUNCTION ag_catalog.age_split(variadic "any")
+CREATE FUNCTION ag_catalog.split(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_split';
 
-CREATE FUNCTION ag_catalog.age_replace(variadic "any")
+CREATE FUNCTION ag_catalog.replace(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_replace';
 
 --
 -- Trig functions - radian input
 --
-CREATE FUNCTION ag_catalog.age_sin(variadic "any")
+CREATE FUNCTION ag_catalog.sin(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_sin';
 
-CREATE FUNCTION ag_catalog.age_cos(variadic "any")
+CREATE FUNCTION ag_catalog.cos(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_cos';
 
-CREATE FUNCTION ag_catalog.age_tan(variadic "any")
+CREATE FUNCTION ag_catalog.tan(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_tan';
 
-CREATE FUNCTION ag_catalog.age_cot(variadic "any")
+CREATE FUNCTION ag_catalog.cot(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_cot';
 
-CREATE FUNCTION ag_catalog.age_asin(variadic "any")
+CREATE FUNCTION ag_catalog.asin(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_asin';
 
-CREATE FUNCTION ag_catalog.age_acos(variadic "any")
+CREATE FUNCTION ag_catalog.acos(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_acos';
 
-CREATE FUNCTION ag_catalog.age_atan(variadic "any")
+CREATE FUNCTION ag_catalog.atan(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_atan';
 
-CREATE FUNCTION ag_catalog.age_atan2(variadic "any")
+CREATE FUNCTION ag_catalog.atan2(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_atan2';
 
-CREATE FUNCTION ag_catalog.age_degrees(variadic "any")
+CREATE FUNCTION ag_catalog.degrees(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_degrees';
 
-CREATE FUNCTION ag_catalog.age_radians(variadic "any")
+CREATE FUNCTION ag_catalog.radians(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_radians';
 
-CREATE FUNCTION ag_catalog.age_round(variadic "any")
+CREATE FUNCTION ag_catalog.round(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_round';
 
-CREATE FUNCTION ag_catalog.age_ceil(variadic "any")
+CREATE FUNCTION ag_catalog.ceil(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_ceil';
 
-CREATE FUNCTION ag_catalog.age_floor(variadic "any")
+CREATE FUNCTION ag_catalog.floor(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_floor';
 
-CREATE FUNCTION ag_catalog.age_abs(variadic "any")
+CREATE FUNCTION ag_catalog.abs(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_abs';
 
-CREATE FUNCTION ag_catalog.age_sign(variadic "any")
+CREATE FUNCTION ag_catalog.sign(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_sign';
 
-CREATE FUNCTION ag_catalog.age_log(variadic "any")
+CREATE FUNCTION ag_catalog.log(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_log';
 
-CREATE FUNCTION ag_catalog.age_log10(variadic "any")
+CREATE FUNCTION ag_catalog.log10(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_log10';
 
-CREATE FUNCTION ag_catalog.age_e()
+CREATE FUNCTION ag_catalog.e()
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_e';
 
-CREATE FUNCTION ag_catalog.age_exp(variadic "any")
+CREATE FUNCTION ag_catalog.exp(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_exp';
 
-CREATE FUNCTION ag_catalog.age_sqrt(variadic "any")
+CREATE FUNCTION ag_catalog.sqrt(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_sqrt';
 
-CREATE FUNCTION age_pi()
+CREATE FUNCTION pi()
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_pi';
 
-CREATE FUNCTION age_rand()
+CREATE FUNCTION rand()
 RETURNS agtype
 LANGUAGE c 
 IMMUTABLE 
 PARALLEL SAFE 
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_rand';
 
-CREATE FUNCTION ag_catalog.age_timestamp()
+CREATE FUNCTION ag_catalog.timestamp()
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_timestamp';
 
 --
 -- count aggregate
 --
-CREATE AGGREGATE age_count(*)
+CREATE AGGREGATE count(*)
 (
     stype = int8,
     sfunc = int8inc,
@@ -3828,7 +3828,7 @@ CREATE AGGREGATE age_count(*)
     parallel = safe
 );
 
-CREATE AGGREGATE age_count(agtype)
+CREATE AGGREGATE count(agtype)
 (
     stype = int8,
     sfunc = int8inc_any,
@@ -3844,28 +3844,28 @@ CREATE AGGREGATE age_count(agtype)
 -- and stdevp(internal, agtype)
 --
 -- wrapper for the stdev final function to pass 0 instead of null
-CREATE FUNCTION ag_catalog.age_float8_stddev_samp_aggfinalfn(_float8)
+CREATE FUNCTION ag_catalog.float8_stddev_samp_aggfinalfn(_float8)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_float8_stddev_samp_aggfinalfn';
 
 -- wrapper for the float8_accum to use agtype input
-CREATE FUNCTION ag_catalog.age_agtype_float8_accum(_float8, agtype)
+CREATE FUNCTION ag_catalog.agtype_float8_accum(_float8, agtype)
 RETURNS _float8
 LANGUAGE c
 IMMUTABLE
 STRICT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_agtype_float8_accum';
 
 -- aggregate definition for age_stdev(agtype)
-CREATE AGGREGATE ag_catalog.age_stdev(agtype)
+CREATE AGGREGATE ag_catalog.stdev(agtype)
 (
    stype = _float8,
-   sfunc = ag_catalog.age_agtype_float8_accum,
-   finalfunc = ag_catalog.age_float8_stddev_samp_aggfinalfn,
+   sfunc = ag_catalog.agtype_float8_accum,
+   finalfunc = ag_catalog.float8_stddev_samp_aggfinalfn,
    combinefunc = float8_combine,
    finalfunc_modify = read_only,
    initcond = '{0,0,0}',
@@ -3873,19 +3873,19 @@ CREATE AGGREGATE ag_catalog.age_stdev(agtype)
 );
 
 -- wrapper for the stdevp final function to pass 0 instead of null
-CREATE FUNCTION ag_catalog.age_float8_stddev_pop_aggfinalfn(_float8)
+CREATE FUNCTION ag_catalog.float8_stddev_pop_aggfinalfn(_float8)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_float8_stddev_pop_aggfinalfn';
 
 -- aggregate definition for age_stdevp(agtype)
-CREATE AGGREGATE ag_catalog.age_stdevp(agtype)
+CREATE AGGREGATE ag_catalog.stdevp(agtype)
 (
    stype = _float8,
-   sfunc = age_agtype_float8_accum,
-   finalfunc = ag_catalog.age_float8_stddev_pop_aggfinalfn,
+   sfunc = agtype_float8_accum,
+   finalfunc = ag_catalog.float8_stddev_pop_aggfinalfn,
    combinefunc = float8_combine,
    finalfunc_modify = read_only,
    initcond = '{0,0,0}',
@@ -3896,10 +3896,10 @@ CREATE AGGREGATE ag_catalog.age_stdevp(agtype)
 -- aggregate function components for avg(agtype) and sum(agtype)
 --
 -- aggregate definition for avg(agytpe)
-CREATE AGGREGATE ag_catalog.age_avg(agtype)
+CREATE AGGREGATE ag_catalog.avg(agtype)
 (
    stype = _float8,
-   sfunc = ag_catalog.age_agtype_float8_accum,
+   sfunc = ag_catalog.agtype_float8_accum,
    finalfunc = float8_avg,
    combinefunc = float8_combine,
    finalfunc_modify = read_only,
@@ -3908,20 +3908,20 @@ CREATE AGGREGATE ag_catalog.age_avg(agtype)
 );
 
 -- sum aggtransfn
-CREATE FUNCTION ag_catalog.age_agtype_sum(agtype, agtype)
+CREATE FUNCTION ag_catalog.agtype_sum(agtype, agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 STRICT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_agtype_sum';
 
 -- aggregate definition for sum(agytpe)
-CREATE AGGREGATE ag_catalog.age_sum(agtype)
+CREATE AGGREGATE ag_catalog.sum(agtype)
 (
    stype = agtype,
-   sfunc = ag_catalog.age_agtype_sum,
-   combinefunc = ag_catalog.age_agtype_sum,
+   sfunc = ag_catalog.agtype_sum,
+   combinefunc = ag_catalog.agtype_sum,
    finalfunc_modify = read_only,
    parallel = safe
 );
@@ -3930,37 +3930,37 @@ CREATE AGGREGATE ag_catalog.age_sum(agtype)
 -- aggregate functions for min(variadic "any") and max(variadic "any")
 --
 -- max transfer function
-CREATE FUNCTION ag_catalog.age_agtype_larger_aggtransfn(agtype, variadic "any")
+CREATE FUNCTION ag_catalog.agtype_larger_aggtransfn(agtype, variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_agtype_larger_aggtransfn';
 
 -- aggregate definition for max(variadic "any")
-CREATE AGGREGATE ag_catalog.age_max(variadic "any")
+CREATE AGGREGATE ag_catalog.max(variadic "any")
 (
    stype = agtype,
-   sfunc = ag_catalog.age_agtype_larger_aggtransfn,
-   combinefunc = ag_catalog.age_agtype_larger_aggtransfn,
+   sfunc = ag_catalog.agtype_larger_aggtransfn,
+   combinefunc = ag_catalog.agtype_larger_aggtransfn,
    finalfunc_modify = read_only,
    parallel = safe
 );
 
 -- min transfer function
-CREATE FUNCTION ag_catalog.age_agtype_smaller_aggtransfn(agtype, variadic "any")
+CREATE FUNCTION ag_catalog.agtype_smaller_aggtransfn(agtype, variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_agtype_smaller_aggtransfn';
 
 -- aggregate definition for min(variadic "any")
-CREATE AGGREGATE ag_catalog.age_min(variadic "any")
+CREATE AGGREGATE ag_catalog.min(variadic "any")
 (
    stype = agtype,
-   sfunc = ag_catalog.age_agtype_smaller_aggtransfn,
-   combinefunc = ag_catalog.age_agtype_smaller_aggtransfn,
+   sfunc = ag_catalog.agtype_smaller_aggtransfn,
+   combinefunc = ag_catalog.agtype_smaller_aggtransfn,
    finalfunc_modify = read_only,
    parallel = safe
 );
@@ -3970,44 +3970,44 @@ CREATE AGGREGATE ag_catalog.age_min(variadic "any")
 -- percentileDisc(internal, agtype)
 --
 -- percentile transfer function
-CREATE FUNCTION ag_catalog.age_percentile_aggtransfn(internal, agtype, agtype)
+CREATE FUNCTION ag_catalog.percentile_aggtransfn(internal, agtype, agtype)
 RETURNS internal
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_percentile_aggtransfn';
 
 -- percentile_cont final function
-CREATE FUNCTION ag_catalog.age_percentile_cont_aggfinalfn(internal)
+CREATE FUNCTION ag_catalog.percentile_cont_aggfinalfn(internal)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_percentile_cont_aggfinalfn';
 
 -- percentile_disc final function
-CREATE FUNCTION ag_catalog.age_percentile_disc_aggfinalfn(internal)
+CREATE FUNCTION ag_catalog.percentile_disc_aggfinalfn(internal)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_percentile_disc_aggfinalfn';
 
 -- aggregate definition for _percentilecont(agtype, agytpe)
-CREATE AGGREGATE ag_catalog.age_percentilecont(agtype, agtype)
+CREATE AGGREGATE ag_catalog.percentilecont(agtype, agtype)
 (
     stype = internal,
-    sfunc = ag_catalog.age_percentile_aggtransfn,
-    finalfunc = ag_catalog.age_percentile_cont_aggfinalfn,
+    sfunc = ag_catalog.percentile_aggtransfn,
+    finalfunc = ag_catalog.percentile_cont_aggfinalfn,
     parallel = safe
 );
 
 -- aggregate definition for percentiledisc(agtype, agytpe)
-CREATE AGGREGATE ag_catalog.age_percentiledisc(agtype, agtype)
+CREATE AGGREGATE ag_catalog.percentiledisc(agtype, agtype)
 (
     stype = internal,
-    sfunc = ag_catalog.age_percentile_aggtransfn,
-    finalfunc = ag_catalog.age_percentile_disc_aggfinalfn,
+    sfunc = ag_catalog.percentile_aggtransfn,
+    finalfunc = ag_catalog.percentile_disc_aggfinalfn,
     parallel = safe
 );
 
@@ -4015,27 +4015,27 @@ CREATE AGGREGATE ag_catalog.age_percentiledisc(agtype, agtype)
 -- aggregate functions for collect(variadic "any")
 --
 -- collect transfer function
-CREATE FUNCTION ag_catalog.age_collect_aggtransfn(internal, variadic "any")
+CREATE FUNCTION ag_catalog.collect_aggtransfn(internal, variadic "any")
 RETURNS internal
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_collect_aggtransfn';
 
 -- collect final function
-CREATE FUNCTION ag_catalog.age_collect_aggfinalfn(internal)
+CREATE FUNCTION ag_catalog.collect_aggfinalfn(internal)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_collect_aggfinalfn';
 
 -- aggregate definition for age_collect(variadic "any")
-CREATE AGGREGATE ag_catalog.age_collect(variadic "any")
+CREATE AGGREGATE ag_catalog.collect(variadic "any")
 (
     stype = internal,
-    sfunc = ag_catalog.age_collect_aggtransfn,
-    finalfunc = ag_catalog.age_collect_aggfinalfn,
+    sfunc = ag_catalog.collect_aggtransfn,
+    finalfunc = ag_catalog.collect_aggfinalfn,
     parallel = safe
 );
 
@@ -4092,7 +4092,7 @@ RETURNS SETOF agtype
 LANGUAGE C
 STABLE
 CALLED ON NULL INPUT
-PARALLEL UNSAFE -- might be safe
+PARALLEL UNSAFE
 AS 'MODULE_PATHNAME';
 
 -- This is an overloaded function definition to allow for the VLE local context
@@ -4104,7 +4104,7 @@ RETURNS SETOF agtype
 LANGUAGE C
 STABLE
 CALLED ON NULL INPUT
-PARALLEL UNSAFE -- might be safe
+PARALLEL UNSAFE
 AS 'MODULE_PATHNAME';
 
 -- function to build an edge for a VLE match
@@ -4161,63 +4161,63 @@ PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 
 -- list functions
-CREATE FUNCTION ag_catalog.age_keys(agtype)
+CREATE FUNCTION ag_catalog.keys(agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_keys';
 
-CREATE FUNCTION ag_catalog.age_labels(agtype)
-RETURNS agtype
-LANGUAGE c
-IMMUTABLE
-RETURNS NULL ON NULL INPUT
-PARALLEL SAFE
-AS 'MODULE_PATHNAME';
-
-CREATE FUNCTION ag_catalog.age_nodes(agtype)
+CREATE FUNCTION ag_catalog.labels(agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 RETURNS NULL ON NULL INPUT
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_labels';
 
-CREATE FUNCTION ag_catalog.age_relationships(agtype)
+CREATE FUNCTION ag_catalog.nodes(agtype)
+RETURNS agtype
+LANGUAGE c
+IMMUTABLE
+RETURNS NULL ON NULL INPUT
+PARALLEL SAFE
+AS 'MODULE_PATHNAME', 'agtype_nodes';
+
+CREATE FUNCTION ag_catalog.relationships(agtype)
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_relationships';
 
-CREATE FUNCTION ag_catalog.age_range(variadic "any")
+CREATE FUNCTION ag_catalog.range(variadic "any")
 RETURNS agtype
 LANGUAGE c
 IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_range';
 
-CREATE FUNCTION ag_catalog.age_unnest(agtype, block_types boolean = false)
+CREATE FUNCTION ag_catalog.unnest(agtype, block_types boolean = false)
     RETURNS SETOF agtype
     LANGUAGE c
     IMMUTABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'agtype_unnest';
 
-CREATE FUNCTION ag_catalog.age_vertex_stats(agtype, agtype)
+CREATE FUNCTION ag_catalog.vertex_stats(agtype, agtype)
 RETURNS agtype
 LANGUAGE c
 STABLE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'age_vertex_stats';
 
-CREATE FUNCTION ag_catalog.age_delete_global_graphs(agtype)
+CREATE FUNCTION ag_catalog.delete_global_graphs(agtype)
 RETURNS boolean
 LANGUAGE c
 VOLATILE
 PARALLEL SAFE
-AS 'MODULE_PATHNAME';
+AS 'MODULE_PATHNAME', 'age_delete_global_graphs';
 
 --
 -- End

--- a/regress/expected/agtype.out
+++ b/regress/expected/agtype.out
@@ -2405,75 +2405,75 @@ HINT:  argument 3 must be an vertex
 --
 -- id, startid, endid
 --
-SELECT age_id(_agtype_build_vertex('1'::graphid, $$label_name$$, agtype_build_map()));
- age_id 
---------
+SELECT id(_agtype_build_vertex('1'::graphid, $$label_name$$, agtype_build_map()));
+ id 
+----
  1
 (1 row)
 
-SELECT age_id(_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
+SELECT id(_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
 			  $$label_name$$, agtype_build_map('id', 2)));
- age_id 
---------
+ id 
+----
  1
 (1 row)
 
-SELECT age_start_id(_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
+SELECT start_id(_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
 			  $$label_name$$, agtype_build_map('id', 2)));
- age_start_id 
---------------
+ start_id 
+----------
  2
 (1 row)
 
-SELECT age_end_id(_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
+SELECT end_id(_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
 			  $$label_name$$, agtype_build_map('id', 2)));
- age_end_id 
-------------
+ end_id 
+--------
  3
 (1 row)
 
-SELECT age_id(_agtype_build_path(
+SELECT id(_agtype_build_path(
 	_agtype_build_vertex('2'::graphid, $$label_name$$, agtype_build_map()),
 	_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
 			  $$label$$, agtype_build_map('id', 2)),
 	_agtype_build_vertex('3'::graphid, $$label$$, agtype_build_map('id', 2))
 ));
 ERROR:  id() argument must be a vertex, an edge or null
-SELECT age_id(agtype_in('1'));
+SELECT id(agtype_in('1'));
 ERROR:  id() argument must be a vertex, an edge or null
-SELECT age_id(NULL);
- age_id 
+SELECT id(NULL);
+ id 
+----
+ 
+(1 row)
+
+SELECT start_id(NULL);
+ start_id 
+----------
+ 
+(1 row)
+
+SELECT end_id(NULL);
+ end_id 
 --------
  
 (1 row)
 
-SELECT age_start_id(NULL);
- age_start_id 
---------------
+SELECT id(agtype_in('null'));
+ id 
+----
  
 (1 row)
 
-SELECT age_end_id(NULL);
- age_end_id 
-------------
+SELECT start_id(agtype_in('null'));
+ start_id 
+----------
  
 (1 row)
 
-SELECT age_id(agtype_in('null'));
- age_id 
+SELECT end_id(agtype_in('null'));
+ end_id 
 --------
- 
-(1 row)
-
-SELECT age_start_id(agtype_in('null'));
- age_start_id 
---------------
- 
-(1 row)
-
-SELECT age_end_id(agtype_in('null'));
- age_end_id 
-------------
  
 (1 row)
 

--- a/regress/expected/cypher_vle.out
+++ b/regress/expected/cypher_vle.out
@@ -49,84 +49,84 @@ SELECT * FROM start_and_end_points;
 SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::agtype, start_vertex, end_vertex, '{"id": 1111111111111111, "label": "", "end_id": 2222222222222222, "start_id": 333333333333333, "properties": {}}::edge'::agtype, '1'::agtype, 'null'::agtype, '1'::agtype) group by ctid;
  count 
 -------
-   400
+ 400
 (1 row)
 
 -- Count the total paths from right (end) to left (start) <-[]- should be 2
 SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::agtype, start_vertex, end_vertex, '{"id": 1111111111111111, "label": "", "end_id": 2222222222222222, "start_id": 333333333333333, "properties": {}}::edge'::agtype, '1'::agtype, 'null'::agtype, '-1'::agtype) group by ctid;
  count 
 -------
-     2
+ 2
 (1 row)
 
 -- Count the total paths undirectional -[]- should be 7092
 SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::agtype, start_vertex, end_vertex, '{"id": 1111111111111111, "label": "", "end_id": 2222222222222222, "start_id": 333333333333333, "properties": {}}::edge'::agtype, '1'::agtype, 'null'::agtype, '0'::agtype) group by ctid;
  count 
 -------
-  7092
+ 7092
 (1 row)
 
 -- All paths of length 3 -[]-> should be 2
 SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::agtype, start_vertex, end_vertex, '{"id": 1111111111111111, "label": "", "end_id": 2222222222222222, "start_id": 333333333333333, "properties": {}}::edge'::agtype, '3'::agtype, '3'::agtype, '1'::agtype);
  count 
 -------
-     2
+ 2
 (1 row)
 
 -- All paths of length 3 <-[]- should be 1
 SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::agtype, start_vertex, end_vertex, '{"id": 1111111111111111, "label": "", "end_id": 2222222222222222, "start_id": 333333333333333, "properties": {}}::edge'::agtype, '3'::agtype, '3'::agtype, '-1'::agtype);
  count 
 -------
-     1
+ 1
 (1 row)
 
 -- All paths of length 3 -[]- should be 12
 SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::agtype, start_vertex, end_vertex, '{"id": 1111111111111111, "label": "", "end_id": 2222222222222222, "start_id": 333333333333333, "properties": {}}::edge'::agtype, '3'::agtype, '3'::agtype, '0'::agtype);
  count 
 -------
-    12
+ 12
 (1 row)
 
 -- Test edge label matching - should match 1
 SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::agtype, start_vertex, end_vertex, '{"id": 1111111111111111, "label": "edge", "end_id": 2222222222222222, "start_id": 333333333333333, "properties": {}}::edge'::agtype, '1'::agtype, 'null'::agtype, '1'::agtype);
  count 
 -------
-     1
+ 1
 (1 row)
 
 -- Test scalar property matching - should match 1
 SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::agtype, start_vertex, end_vertex, '{"id": 1111111111111111, "label": "", "end_id": 2222222222222222, "start_id": 333333333333333, "properties": {"name": "main edge"}}::edge'::agtype, '1'::agtype, 'null'::agtype, '1'::agtype);
  count 
 -------
-     1
+ 1
 (1 row)
 
 -- Test object property matching - should match 4
 SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::agtype, start_vertex, end_vertex, '{"id": 1111111111111111, "label": "", "end_id": 2222222222222222, "start_id": 333333333333333, "properties": {"dangerous": {"type": "all", "level": "all"}}}::edge'::agtype, '1'::agtype, 'null'::agtype, '1'::agtype);
  count 
 -------
-     4
+ 4
 (1 row)
 
 -- Test array property matching - should match 2
 SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::agtype, start_vertex, end_vertex, '{"id": 1111111111111111, "label": "", "end_id": 2222222222222222, "start_id": 333333333333333, "properties": {"packages": [1,3,5,7]}}::edge'::agtype, '1'::agtype, 'null'::agtype, '0'::agtype);
  count 
 -------
-     2
+ 2
 (1 row)
 
 -- Test array property matching - should match 1
 SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::agtype, start_vertex, end_vertex, '{"id": 1111111111111111, "label": "", "end_id": 2222222222222222, "start_id": 333333333333333, "properties": {"packages": [2,4,6]}}::edge'::agtype, '1'::agtype, 'null'::agtype, '0'::agtype);
  count 
 -------
-     1
+ 1
 (1 row)
 
 -- Test object property matching - should match 1
 SELECT count(edges) FROM start_and_end_points, age_vle( '"cypher_vle"'::agtype, start_vertex, end_vertex, '{"id": 1111111111111111, "label": "", "end_id": 2222222222222222, "start_id": 333333333333333, "properties": {"dangerous": {"type": "poisons", "level": "all"}}}::edge'::agtype, '1'::agtype, 'null'::agtype, '0'::agtype);
  count 
 -------
-     1
+ 1
 (1 row)
 
 -- Test the VLE match integration

--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -1256,7 +1256,7 @@ SELECT * FROM cypher('type_coercion', $$
 $$) AS (i bigint);
 ERROR:  cannot cast agtype path to type int
 --
--- Test typecasting '::' transform and execution logic
+-- Test typecasting '::' 
 --
 --
 -- Test from an agtype value to agtype int
@@ -2068,7 +2068,7 @@ $$) AS (id agtype);
 SELECT * FROM cypher('expr', $$
     RETURN id()
 $$) AS (id agtype);
-ERROR:  function ag_catalog.age_id() does not exist
+ERROR:  function ag_catalog.id() does not exist
 LINE 2:     RETURN id()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2101,7 +2101,7 @@ ERROR:  start_id() argument must be an edge or null
 SELECT * FROM cypher('expr', $$
     RETURN start_id()
 $$) AS (start_id agtype);
-ERROR:  function ag_catalog.age_start_id() does not exist
+ERROR:  function ag_catalog.start_id() does not exist
 LINE 2:     RETURN start_id()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2134,7 +2134,7 @@ ERROR:  end_id() argument must be an edge or null
 SELECT * FROM cypher('expr', $$
     RETURN end_id()
 $$) AS (end_id agtype);
-ERROR:  function ag_catalog.age_end_id() does not exist
+ERROR:  function ag_catalog.end_id() does not exist
 LINE 2:     RETURN end_id()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2167,7 +2167,7 @@ ERROR:  startNode() argument must be an edge or null
 SELECT * FROM cypher('expr', $$
     RETURN startNode()
 $$) AS (startNode agtype);
-ERROR:  function ag_catalog.age_startnode() does not exist
+ERROR:  function ag_catalog.startnode() does not exist
 LINE 2:     RETURN startNode()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2200,7 +2200,7 @@ ERROR:  endNode() argument must be an edge or null
 SELECT * FROM cypher('expr', $$
     RETURN endNode()
 $$) AS (endNode agtype);
-ERROR:  function ag_catalog.age_endnode() does not exist
+ERROR:  function ag_catalog.endnode() does not exist
 LINE 2:     RETURN endNode()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2233,7 +2233,7 @@ ERROR:  type() argument must be an edge or null
 SELECT * FROM cypher('expr', $$
     RETURN type()
 $$) AS (type agtype);
-ERROR:  function ag_catalog.age_type() does not exist
+ERROR:  function ag_catalog.type() does not exist
 LINE 2:     RETURN type()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2277,9 +2277,9 @@ $$) AS (label agtype);
  
 (1 row)
 
-SELECT ag_catalog.age_label(NULL);
- age_label 
------------
+SELECT ag_catalog.label(NULL);
+ label 
+-------
  
 (1 row)
 
@@ -2352,7 +2352,7 @@ ERROR:  size() unsupported argument
 SELECT * FROM cypher('expr', $$
     RETURN size()
 $$) AS (size agtype);
-ERROR:  function ag_catalog.age_size() does not exist
+ERROR:  function ag_catalog.size() does not exist
 LINE 2:     RETURN size()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2398,7 +2398,7 @@ ERROR:  head() argument must resolve to a list or null
 SELECT * FROM cypher('expr', $$
     RETURN head()
 $$) AS (head agtype);
-ERROR:  function ag_catalog.age_head() does not exist
+ERROR:  function ag_catalog.head() does not exist
 LINE 2:     RETURN head()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2444,7 +2444,7 @@ ERROR:  last() argument must resolve to a list or null
 SELECT * FROM cypher('expr', $$
     RETURN last()
 $$) AS (last agtype);
-ERROR:  function ag_catalog.age_last() does not exist
+ERROR:  function ag_catalog.last() does not exist
 LINE 2:     RETURN last()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2490,7 +2490,7 @@ ERROR:  properties() argument must be a vertex, an edge or null
 SELECT * FROM cypher('expr', $$
     RETURN properties()
 $$) AS (properties agtype);
-ERROR:  function ag_catalog.age_properties() does not exist
+ERROR:  function ag_catalog.properties() does not exist
 LINE 2:     RETURN properties()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2617,7 +2617,7 @@ ERROR:  toBoolean() unsupported argument agtype 3
 SELECT * FROM cypher('expr', $$
     RETURN toBoolean()
 $$) AS (toBoolean agtype);
-ERROR:  function ag_catalog.age_toboolean() does not exist
+ERROR:  function ag_catalog.toboolean() does not exist
 LINE 2:     RETURN toBoolean()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2687,7 +2687,7 @@ ERROR:  toFloat() unsupported argument agtype 5
 SELECT * FROM cypher('expr', $$
     RETURN toFloat()
 $$) AS (toFloat agtype);
-ERROR:  function ag_catalog.age_tofloat() does not exist
+ERROR:  function ag_catalog.tofloat() does not exist
 LINE 2:     RETURN toFloat()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2757,7 +2757,7 @@ ERROR:  toInteger() unsupported argument agtype 5
 SELECT * FROM cypher('expr', $$
     RETURN toInteger()
 $$) AS (toInteger agtype);
-ERROR:  function ag_catalog.age_tointeger() does not exist
+ERROR:  function ag_catalog.tointeger() does not exist
 LINE 2:     RETURN toInteger()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2795,7 +2795,7 @@ ERROR:  length() argument must resolve to a path or null
 SELECT * FROM cypher('expr', $$
     RETURN length()
 $$) AS (length agtype);
-ERROR:  function ag_catalog.age_length() does not exist
+ERROR:  function ag_catalog.length() does not exist
 LINE 2:     RETURN length()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2803,100 +2803,100 @@ HINT:  No function matches the given name and argument types. You might need to 
 -- toString()
 --
 -- PG types
-SELECT * FROM age_toString(3);
- age_tostring 
---------------
+SELECT * FROM toString(3);
+ tostring 
+----------
  "3"
 (1 row)
 
-SELECT * FROM age_toString(3.14);
- age_tostring 
---------------
+SELECT * FROM toString(3.14);
+ tostring 
+----------
  "3.14"
 (1 row)
 
-SELECT * FROM age_toString(3.14::float);
- age_tostring 
---------------
+SELECT * FROM toString(3.14::float);
+ tostring 
+----------
  "3.14"
 (1 row)
 
-SELECT * FROM age_toString(3.14::numeric);
- age_tostring 
---------------
+SELECT * FROM toString(3.14::numeric);
+ tostring 
+----------
  "3.14"
 (1 row)
 
-SELECT * FROM age_toString(true);
- age_tostring 
---------------
+SELECT * FROM toString(true);
+ tostring 
+----------
  "true"
 (1 row)
 
-SELECT * FROM age_toString(false);
- age_tostring 
---------------
+SELECT * FROM toString(false);
+ tostring 
+----------
  "false"
 (1 row)
 
-SELECT * FROM age_toString('a string');
- age_tostring 
---------------
+SELECT * FROM toString('a string');
+  tostring  
+------------
  "a string"
 (1 row)
 
-SELECT * FROM age_toString('a cstring'::cstring);
- age_tostring 
---------------
+SELECT * FROM toString('a cstring'::cstring);
+  tostring   
+-------------
  "a cstring"
 (1 row)
 
-SELECT * FROM age_toString('a text string'::text);
-  age_tostring   
+SELECT * FROM toString('a text string'::text);
+    tostring     
 -----------------
  "a text string"
 (1 row)
 
 -- agtypes
-SELECT * FROM age_toString(agtype_in('3'));
- age_tostring 
---------------
+SELECT * FROM toString(agtype_in('3'));
+ tostring 
+----------
  "3"
 (1 row)
 
-SELECT * FROM age_toString(agtype_in('3.14'));
- age_tostring 
---------------
+SELECT * FROM toString(agtype_in('3.14'));
+ tostring 
+----------
  "3.14"
 (1 row)
 
-SELECT * FROM age_toString(agtype_in('3.14::float'));
- age_tostring 
---------------
+SELECT * FROM toString(agtype_in('3.14::float'));
+ tostring 
+----------
  "3.14"
 (1 row)
 
-SELECT * FROM age_toString(agtype_in('3.14::numeric'));
- age_tostring 
---------------
+SELECT * FROM toString(agtype_in('3.14::numeric'));
+ tostring 
+----------
  "3.14"
 (1 row)
 
-SELECT * FROM age_toString(agtype_in('true'));
- age_tostring 
---------------
+SELECT * FROM toString(agtype_in('true'));
+ tostring 
+----------
  "true"
 (1 row)
 
-SELECT * FROM age_toString(agtype_in('false'));
- age_tostring 
---------------
+SELECT * FROM toString(agtype_in('false'));
+ tostring 
+----------
  "false"
 (1 row)
 
-SELECT * FROM age_toString(agtype_in('"a string"'));
- age_tostring 
---------------
+SELECT * FROM toString(agtype_in('"a string"'));
+  tostring  
+------------
  "a string"
 (1 row)
 
@@ -2907,26 +2907,26 @@ SELECT * FROM cypher('expr', $$ RETURN toString(3.14::numeric) $$) AS (results a
 (1 row)
 
 -- should return null
-SELECT * FROM age_toString(NULL);
- age_tostring 
---------------
+SELECT * FROM toString(NULL);
+ tostring 
+----------
  
 (1 row)
 
-SELECT * FROM age_toString(agtype_in(null));
- age_tostring 
---------------
+SELECT * FROM toString(agtype_in(null));
+ tostring 
+----------
  
 (1 row)
 
 -- should fail
-SELECT * FROM age_toString();
-ERROR:  function age_tostring() does not exist
-LINE 1: SELECT * FROM age_toString();
+SELECT * FROM toString();
+ERROR:  function tostring() does not exist
+LINE 1: SELECT * FROM toString();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$ RETURN toString() $$) AS (results agtype);
-ERROR:  function ag_catalog.age_tostring() does not exist
+ERROR:  function ag_catalog.tostring() does not exist
 LINE 1: SELECT * FROM cypher('expr', $$ RETURN toString() $$) AS (re...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -2941,20 +2941,20 @@ $$) AS (results agtype);
  "this is a string"
 (1 row)
 
-SELECT * FROM age_reverse('gnirts a si siht');
-    age_reverse     
---------------------
- "this is a string"
+SELECT * FROM reverse('gnirts a si siht');
+     reverse      
+------------------
+ this is a string
 (1 row)
 
-SELECT * FROM age_reverse('gnirts a si siht'::text);
-    age_reverse     
---------------------
- "this is a string"
+SELECT * FROM reverse('gnirts a si siht'::text);
+     reverse      
+------------------
+ this is a string
 (1 row)
 
-SELECT * FROM age_reverse('gnirts a si siht'::cstring);
-    age_reverse     
+SELECT * FROM reverse('gnirts a si siht'::cstring);
+      reverse       
 --------------------
  "this is a string"
 (1 row)
@@ -2968,17 +2968,17 @@ $$) AS (results agtype);
  
 (1 row)
 
-SELECT * FROM age_reverse(null);
- age_reverse 
--------------
+SELECT * FROM reverse(null);
+ reverse 
+---------
  
 (1 row)
 
 -- should return error
-SELECT * FROM age_reverse([4923, 'abc', 521, NULL, 487]);
+SELECT * FROM reverse([4923, 'abc', 521, NULL, 487]);
 ERROR:  syntax error at or near "["
-LINE 1: SELECT * FROM age_reverse([4923, 'abc', 521, NULL, 487]);
-                                  ^
+LINE 1: SELECT * FROM reverse([4923, 'abc', 521, NULL, 487]);
+                              ^
 -- Should return the reversed list
 SELECT * FROM cypher('expr', $$
     RETURN reverse([4923, 'abc', 521, NULL, 487])
@@ -3056,24 +3056,24 @@ SELECT * FROM cypher('expr', $$
     RETURN reverse(true)
 $$) AS (results agtype);
 ERROR:  reverse() unsupported argument agtype 5
-SELECT * FROM age_reverse(true);
+SELECT * FROM reverse(true);
 ERROR:  reverse() unsupported argument type 16
 SELECT * FROM cypher('expr', $$
     RETURN reverse(3.14)
 $$) AS (results agtype);
 ERROR:  reverse() unsupported argument agtype 4
-SELECT * FROM age_reverse(3.14);
+SELECT * FROM reverse(3.14);
 ERROR:  reverse() unsupported argument type 1700
 SELECT * FROM cypher('expr', $$
     RETURN reverse()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_reverse() does not exist
+ERROR:  function ag_catalog.reverse() does not exist
 LINE 2:     RETURN reverse()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_reverse();
-ERROR:  function age_reverse() does not exist
-LINE 1: SELECT * FROM age_reverse();
+SELECT * FROM reverse();
+ERROR:  function reverse() does not exist
+LINE 1: SELECT * FROM reverse();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
@@ -3095,27 +3095,27 @@ $$) AS (toLower agtype);
  "to lowercase"
 (1 row)
 
-SELECT * FROM age_toupper('text'::text);
- age_toupper 
--------------
+SELECT * FROM toupper('text'::text);
+ toupper 
+---------
  "TEXT"
 (1 row)
 
-SELECT * FROM age_toupper('cstring'::cstring);
- age_toupper 
--------------
+SELECT * FROM toupper('cstring'::cstring);
+  toupper  
+-----------
  "CSTRING"
 (1 row)
 
-SELECT * FROM age_tolower('TEXT'::text);
- age_tolower 
--------------
+SELECT * FROM tolower('TEXT'::text);
+ tolower 
+---------
  "text"
 (1 row)
 
-SELECT * FROM age_tolower('CSTRING'::cstring);
- age_tolower 
--------------
+SELECT * FROM tolower('CSTRING'::cstring);
+  tolower  
+-----------
  "cstring"
 (1 row)
 
@@ -3136,15 +3136,15 @@ $$) AS (toLower agtype);
  
 (1 row)
 
-SELECT * FROM age_toupper(null);
- age_toupper 
--------------
+SELECT * FROM toupper(null);
+ toupper 
+---------
  
 (1 row)
 
-SELECT * FROM age_tolower(null);
- age_tolower 
--------------
+SELECT * FROM tolower(null);
+ tolower 
+---------
  
 (1 row)
 
@@ -3156,7 +3156,7 @@ ERROR:  toUpper() unsupported argument agtype 5
 SELECT * FROM cypher('expr', $$
     RETURN toUpper()
 $$) AS (toUpper agtype);
-ERROR:  function ag_catalog.age_toupper() does not exist
+ERROR:  function ag_catalog.toupper() does not exist
 LINE 2:     RETURN toUpper()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -3167,18 +3167,18 @@ ERROR:  toLower() unsupported argument agtype 5
 SELECT * FROM cypher('expr', $$
     RETURN toLower()
 $$) AS (toLower agtype);
-ERROR:  function ag_catalog.age_tolower() does not exist
+ERROR:  function ag_catalog.tolower() does not exist
 LINE 2:     RETURN toLower()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_toupper();
-ERROR:  function age_toupper() does not exist
-LINE 1: SELECT * FROM age_toupper();
+SELECT * FROM toupper();
+ERROR:  function toupper() does not exist
+LINE 1: SELECT * FROM toupper();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_tolower();
-ERROR:  function age_tolower() does not exist
-LINE 1: SELECT * FROM age_tolower();
+SELECT * FROM tolower();
+ERROR:  function tolower() does not exist
+LINE 1: SELECT * FROM tolower();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
@@ -3208,22 +3208,22 @@ $$) AS (results agtype);
  "string"
 (1 row)
 
-SELECT * FROM age_ltrim('  string   ');
-  age_ltrim  
--------------
- "string   "
+SELECT * FROM ltrim('  string   ');
+   ltrim   
+-----------
+ string   
 (1 row)
 
-SELECT * FROM age_rtrim('  string   ');
- age_rtrim  
-------------
- "  string"
-(1 row)
-
-SELECT * FROM age_trim('  string   ');
- age_trim 
+SELECT * FROM rtrim('  string   ');
+  rtrim   
 ----------
- "string"
+   string
+(1 row)
+
+SELECT * FROM trim('  string   ');
+ btrim  
+--------
+ string
 (1 row)
 
 -- should return null
@@ -3251,21 +3251,21 @@ $$) AS (results agtype);
  
 (1 row)
 
-SELECT * FROM age_ltrim(null);
- age_ltrim 
------------
+SELECT * FROM ltrim(null);
+ ltrim 
+-------
  
 (1 row)
 
-SELECT * FROM age_rtrim(null);
- age_rtrim 
------------
+SELECT * FROM rtrim(null);
+ rtrim 
+-------
  
 (1 row)
 
-SELECT * FROM age_trim(null);
- age_trim 
-----------
+SELECT * FROM trim(null);
+ btrim 
+-------
  
 (1 row)
 
@@ -3285,39 +3285,38 @@ ERROR:  trim() unsupported argument agtype 5
 SELECT * FROM cypher('expr', $$
     RETURN lTrim()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_ltrim() does not exist
+ERROR:  function ag_catalog.ltrim() does not exist
 LINE 2:     RETURN lTrim()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN rTrim()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_rtrim() does not exist
+ERROR:  function ag_catalog.rtrim() does not exist
 LINE 2:     RETURN rTrim()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN trim()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_trim() does not exist
+ERROR:  function ag_catalog.trim() does not exist
 LINE 2:     RETURN trim()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_ltrim();
-ERROR:  function age_ltrim() does not exist
-LINE 1: SELECT * FROM age_ltrim();
+SELECT * FROM ltrim();
+ERROR:  function ltrim() does not exist
+LINE 1: SELECT * FROM ltrim();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_rtrim();
-ERROR:  function age_rtrim() does not exist
-LINE 1: SELECT * FROM age_rtrim();
+SELECT * FROM rtrim();
+ERROR:  function rtrim() does not exist
+LINE 1: SELECT * FROM rtrim();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_trim();
-ERROR:  function age_trim() does not exist
-LINE 1: SELECT * FROM age_trim();
-                      ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT * FROM trim();
+ERROR:  syntax error at or near ")"
+LINE 1: SELECT * FROM trim();
+                           ^
 --
 -- left(), right(), & substring()
 -- left()
@@ -3362,18 +3361,17 @@ $$) AS (results agtype);
  
 (1 row)
 
-SELECT * FROM age_left(null, 1);
- age_left 
-----------
+SELECT * FROM left(null, 1);
+ left 
+------
  
 (1 row)
 
-SELECT * FROM age_left(null, null);
- age_left 
-----------
- 
-(1 row)
-
+SELECT * FROM left(null, null);
+ERROR:  function left(unknown, unknown) is not unique
+LINE 1: SELECT * FROM left(null, null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN left("123456789", null)
@@ -3386,17 +3384,17 @@ ERROR:  left() negative values are not supported for length
 SELECT * FROM cypher('expr', $$
     RETURN left()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_left() does not exist
+ERROR:  function ag_catalog.left() does not exist
 LINE 2:     RETURN left()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_left('123456789', null);
+SELECT * FROM left('"123456789"'::agtype, null);
 ERROR:  left() length parameter cannot be null
-SELECT * FROM age_left('123456789', -1);
+SELECT * FROM left('"123456789"'::agtype, -1);
 ERROR:  left() negative values are not supported for length
-SELECT * FROM age_left();
-ERROR:  function age_left() does not exist
-LINE 1: SELECT * FROM age_left();
+SELECT * FROM left();
+ERROR:  function left() does not exist
+LINE 1: SELECT * FROM left();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --right()
@@ -3441,18 +3439,17 @@ $$) AS (results agtype);
  
 (1 row)
 
-SELECT * FROM age_right(null, 1);
- age_right 
------------
+SELECT * FROM right(null, 1);
+ right 
+-------
  
 (1 row)
 
-SELECT * FROM age_right(null, null);
- age_right 
------------
- 
-(1 row)
-
+SELECT * FROM right(null, null);
+ERROR:  function right(unknown, unknown) is not unique
+LINE 1: SELECT * FROM right(null, null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN right("123456789", null)
@@ -3465,17 +3462,24 @@ ERROR:  right() negative values are not supported for length
 SELECT * FROM cypher('expr', $$
     RETURN right()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_right() does not exist
+ERROR:  function ag_catalog.right() does not exist
 LINE 2:     RETURN right()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_right('123456789', null);
-ERROR:  right() length parameter cannot be null
-SELECT * FROM age_right('123456789', -1);
-ERROR:  right() negative values are not supported for length
-SELECT * FROM age_right();
-ERROR:  function age_right() does not exist
-LINE 1: SELECT * FROM age_right();
+SELECT * FROM right('123456789', null);
+ERROR:  function right(unknown, unknown) is not unique
+LINE 1: SELECT * FROM right('123456789', null);
+                      ^
+HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
+SELECT * FROM right('123456789', -1);
+  right   
+----------
+ 23456789
+(1 row)
+
+SELECT * FROM right();
+ERROR:  function right() does not exist
+LINE 1: SELECT * FROM right();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 -- substring()
@@ -3511,16 +3515,16 @@ $$) AS (results agtype);
  "0123456789"
 (1 row)
 
-SELECT * FROM age_substring('0123456789', 3, 2);
- age_substring 
----------------
- "34"
+SELECT * FROM substring('0123456789', 3, 2);
+ substring 
+-----------
+ 23
 (1 row)
 
-SELECT * FROM age_substring('0123456789', 1);
- age_substring 
----------------
- "123456789"
+SELECT * FROM substring('0123456789', 1);
+ substring  
+------------
+ 0123456789
 (1 row)
 
 -- should return null
@@ -3548,21 +3552,21 @@ $$) AS (results agtype);
  
 (1 row)
 
-SELECT * FROM age_substring(null, null, null);
- age_substring 
----------------
+SELECT * FROM substring(null, null, null);
+ substring 
+-----------
  
 (1 row)
 
-SELECT * FROM age_substring(null, null);
- age_substring 
----------------
+SELECT * FROM substring(null, null);
+ substring 
+-----------
  
 (1 row)
 
-SELECT * FROM age_substring(null, 1);
- age_substring 
----------------
+SELECT * FROM substring(null, 1);
+ substring 
+-----------
  
 (1 row)
 
@@ -3583,15 +3587,23 @@ SELECT * FROM cypher('expr', $$
     RETURN substring("123456789")
 $$) AS (results agtype);
 ERROR:  substring() invalid number of arguments
-SELECT * FROM age_substring('123456789', null);
-ERROR:  substring() offset or length cannot be null
-SELECT * FROM age_substring('123456789', 0, -1);
-ERROR:  substring() negative values are not supported for offset or length
-SELECT * FROM age_substring('123456789', -1);
-ERROR:  substring() negative values are not supported for offset or length
-SELECT * FROM age_substring();
-ERROR:  function age_substring() does not exist
-LINE 1: SELECT * FROM age_substring();
+SELECT * FROM substring('123456789', null);
+ substring 
+-----------
+ 
+(1 row)
+
+SELECT * FROM substring('123456789', 0, -1);
+ERROR:  negative substring length not allowed
+SELECT * FROM substring('123456789', -1);
+ substring 
+-----------
+ 123456789
+(1 row)
+
+SELECT * FROM substring();
+ERROR:  function substring() does not exist
+LINE 1: SELECT * FROM substring();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
@@ -3670,21 +3682,21 @@ $$) AS (results agtype);
  
 (1 row)
 
-SELECT * FROM age_split(null, null);
- age_split 
------------
+SELECT * FROM split(null, null);
+ split 
+-------
  
 (1 row)
 
-SELECT * FROM age_split('a,b,c,d,e,f', null);
- age_split 
------------
+SELECT * FROM split('a,b,c,d,e,f', null);
+ split 
+-------
  
 (1 row)
 
-SELECT * FROM age_split(null, ',');
- age_split 
------------
+SELECT * FROM split(null, ',');
+ split 
+-------
  
 (1 row)
 
@@ -3704,19 +3716,19 @@ ERROR:  split() invalid number of arguments
 SELECT * FROM cypher('expr', $$
     RETURN split()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_split() does not exist
+ERROR:  function ag_catalog.split() does not exist
 LINE 2:     RETURN split()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_split(123456789, ',');
+SELECT * FROM split(123456789, ',');
 ERROR:  split() unsupported argument type 23
-SELECT * FROM age_split('a,b,c,d,e,f', -1);
+SELECT * FROM split('a,b,c,d,e,f', -1);
 ERROR:  split() unsupported argument type 23
-SELECT * FROM age_split('a,b,c,d,e,f');
+SELECT * FROM split('a,b,c,d,e,f');
 ERROR:  split() invalid number of arguments
-SELECT * FROM age_split();
-ERROR:  function age_split() does not exist
-LINE 1: SELECT * FROM age_split();
+SELECT * FROM split();
+ERROR:  function split() does not exist
+LINE 1: SELECT * FROM split();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
@@ -3811,39 +3823,39 @@ $$) AS (results agtype);
  
 (1 row)
 
-SELECT * FROM age_replace(null, null, null);
- age_replace 
--------------
+SELECT * FROM replace(null, null, null);
+ replace 
+---------
  
 (1 row)
 
-SELECT * FROM age_replace('Hello', null, null);
- age_replace 
--------------
+SELECT * FROM replace('Hello', null, null);
+ replace 
+---------
  
 (1 row)
 
-SELECT * FROM age_replace('Hello', '', null);
- age_replace 
--------------
+SELECT * FROM replace('Hello', '', null);
+ replace 
+---------
  
 (1 row)
 
-SELECT * FROM age_replace('', '', '');
- age_replace 
--------------
+SELECT * FROM replace('', '', '');
+ replace 
+---------
  
 (1 row)
 
-SELECT * FROM age_replace('Hello', 'Hello', '');
- age_replace 
--------------
+SELECT * FROM replace('Hello', 'Hello', '');
+ replace 
+---------
  
 (1 row)
 
-SELECT * FROM age_replace('', 'Hello', 'Mellow');
- age_replace 
--------------
+SELECT * FROM replace('', 'Hello', 'Mellow');
+ replace 
+---------
  
 (1 row)
 
@@ -3851,7 +3863,7 @@ SELECT * FROM age_replace('', 'Hello', 'Mellow');
 SELECT * FROM cypher('expr', $$
     RETURN replace()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_replace() does not exist
+ERROR:  function ag_catalog.replace() does not exist
 LINE 2:     RETURN replace()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -3871,18 +3883,18 @@ SELECT * FROM cypher('expr', $$
     RETURN replace("Hello", 1, "e")
 $$) AS (results agtype);
 ERROR:  replace() unsupported argument agtype 3
-SELECT * FROM age_replace();
-ERROR:  function age_replace() does not exist
-LINE 1: SELECT * FROM age_replace();
+SELECT * FROM replace();
+ERROR:  function replace() does not exist
+LINE 1: SELECT * FROM replace();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_replace(null);
+SELECT * FROM replace(null);
 ERROR:  replace() invalid number of arguments
-SELECT * FROM age_replace(null, null);
+SELECT * FROM replace(null, null);
 ERROR:  replace() invalid number of arguments
-SELECT * FROM age_replace('Hello', 'e', 1);
+SELECT * FROM replace('Hello', 'e', 1);
 ERROR:  replace() unsupported argument type 23
-SELECT * FROM age_replace('Hello', 1, 'E');
+SELECT * FROM replace('Hello', 1, 'E');
 ERROR:  replace() unsupported argument type 23
 --
 -- sin, cos, tan, cot
@@ -3919,25 +3931,25 @@ $$) AS (results agtype), cot(3.1415);
  t
 (1 row)
 
-SELECT sin = age_sin FROM sin(3.1415), age_sin(3.1415);
+SELECT agtype_sin = float_sin FROM sin(3.1415::float8) as float_sin, sin('3.1415'::agtype) AS agtype_sin;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT cos = age_cos FROM cos(3.1415), age_cos(3.1415);
+SELECT agtype_cos = float_cos FROM cos(3.1415::float8) as float_cos, cos('3.1415'::agtype) AS agtype_cos;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT tan = age_tan FROM tan(3.1415), age_tan(3.1415);
+SELECT agtype_tan = float_tan FROM tan(3.1415::float8) as float_tan, tan('3.1415'::agtype) AS agtype_tan;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT cot = age_cot FROM cot(3.1415), age_cot(3.1415);
+SELECT agtype_cot = float_cot FROM cot(3.1415::float8) as float_cot, cot('3.1415'::agtype) AS agtype_cot;
  ?column? 
 ----------
  t
@@ -3976,27 +3988,27 @@ $$) AS (results agtype);
  
 (1 row)
 
-SELECT * FROM age_sin(null);
- age_sin 
----------
+SELECT * FROM sin(null::agtype);
+ sin 
+-----
  
 (1 row)
 
-SELECT * FROM age_cos(null);
- age_cos 
----------
+SELECT * FROM cos(null::agtype);
+ cos 
+-----
  
 (1 row)
 
-SELECT * FROM age_tan(null);
- age_tan 
----------
+SELECT * FROM tan(null::agtype);
+ tan 
+-----
  
 (1 row)
 
-SELECT * FROM age_cot(null);
- age_cot 
----------
+SELECT * FROM cot(null::agtype);
+ cot 
+-----
  
 (1 row)
 
@@ -4020,57 +4032,57 @@ ERROR:  cot() unsupported argument agtype 1
 SELECT * FROM cypher('expr', $$
     RETURN sin()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_sin() does not exist
+ERROR:  function ag_catalog.sin() does not exist
 LINE 2:     RETURN sin()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN cos()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_cos() does not exist
+ERROR:  function ag_catalog.cos() does not exist
 LINE 2:     RETURN cos()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN tan()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_tan() does not exist
+ERROR:  function ag_catalog.tan() does not exist
 LINE 2:     RETURN tan()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN cot()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_cot() does not exist
+ERROR:  function ag_catalog.cot() does not exist
 LINE 2:     RETURN cot()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_sin('0');
-ERROR:  sin() unsupported argument type 25
-SELECT * FROM age_cos('0');
-ERROR:  cos() unsupported argument type 25
-SELECT * FROM age_tan('0');
-ERROR:  tan() unsupported argument type 25
-SELECT * FROM age_cot('0');
-ERROR:  cot() unsupported argument type 25
-SELECT * FROM age_sin();
-ERROR:  function age_sin() does not exist
-LINE 1: SELECT * FROM age_sin();
+SELECT * FROM sin('"0"'::agtype);
+ERROR:  sin() unsupported argument agtype 1
+SELECT * FROM cos('"0"'::agtype);
+ERROR:  cos() unsupported argument agtype 1
+SELECT * FROM tan('"0"'::agtype);
+ERROR:  tan() unsupported argument agtype 1
+SELECT * FROM cot('"0"'::agtype);
+ERROR:  cot() unsupported argument agtype 1
+SELECT * FROM sin();
+ERROR:  function sin() does not exist
+LINE 1: SELECT * FROM sin();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_cos();
-ERROR:  function age_cos() does not exist
-LINE 1: SELECT * FROM age_cos();
+SELECT * FROM cos();
+ERROR:  function cos() does not exist
+LINE 1: SELECT * FROM cos();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_tan();
-ERROR:  function age_tan() does not exist
-LINE 1: SELECT * FROM age_tan();
+SELECT * FROM tan();
+ERROR:  function tan() does not exist
+LINE 1: SELECT * FROM tan();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_cot();
-ERROR:  function age_cot() does not exist
-LINE 1: SELECT * FROM age_cot();
+SELECT * FROM cot();
+ERROR:  function cot() does not exist
+LINE 1: SELECT * FROM cot();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
@@ -4108,26 +4120,26 @@ $$) AS (results agtype);
  3.14159265358979
 (1 row)
 
-SELECT * FROM asin(1), age_asin(1);
-      asin       |    age_asin     
+SELECT * FROM asin(1::int), asin('1'::agtype) as agtype_asin;
+      asin       |   agtype_asin   
 -----------------+-----------------
  1.5707963267949 | 1.5707963267949
 (1 row)
 
-SELECT * FROM acos(0), age_acos(0);
-      acos       |    age_acos     
+SELECT * FROM acos(0), acos('0'::agtype) as agtype_acos;
+      acos       |   agtype_acos   
 -----------------+-----------------
  1.5707963267949 | 1.5707963267949
 (1 row)
 
-SELECT * FROM atan(1), age_atan(1);
-       atan        |     age_atan      
+SELECT * FROM atan(1), atan('1'::agtype) as agtype_atan;
+       atan        |    agtype_atan    
 -------------------+-------------------
  0.785398163397448 | 0.785398163397448
 (1 row)
 
-SELECT * FROM atan2(1, 1), age_atan2(1, 1);
-       atan2       |     age_atan2     
+SELECT * FROM atan2(1, 1), atan2('1'::agtype, '1'::agtype) as agtype_atan;
+       atan2       |    agtype_atan    
 -------------------+-------------------
  0.785398163397448 | 0.785398163397448
 (1 row)
@@ -4213,39 +4225,39 @@ $$) AS (results agtype);
  
 (1 row)
 
-SELECT * FROM age_asin(null);
- age_asin 
-----------
+SELECT * FROM asin(null::agtype);
+ asin 
+------
  
 (1 row)
 
-SELECT * FROM age_acos(null);
- age_acos 
-----------
+SELECT * FROM acos(null::agtype);
+ acos 
+------
  
 (1 row)
 
-SELECT * FROM age_atan(null);
- age_atan 
-----------
+SELECT * FROM atan(null::agtype);
+ atan 
+------
  
 (1 row)
 
-SELECT * FROM age_atan2(null, null);
- age_atan2 
------------
+SELECT * FROM atan2(null, null::agtype);
+ atan2 
+-------
  
 (1 row)
 
-SELECT * FROM age_atan2(1, null);
- age_atan2 
------------
+SELECT * FROM atan2(1, null::agtype);
+ atan2 
+-------
  
 (1 row)
 
-SELECT * FROM age_atan2(null, 1);
- age_atan2 
------------
+SELECT * FROM atan2(null::agtype, 1);
+ atan2 
+-------
  
 (1 row)
 
@@ -4273,28 +4285,28 @@ ERROR:  atan2() unsupported argument agtype 1
 SELECT * FROM cypher('expr', $$
     RETURN asin()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_asin() does not exist
+ERROR:  function ag_catalog.asin() does not exist
 LINE 2:     RETURN asin()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN acos()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_acos() does not exist
+ERROR:  function ag_catalog.acos() does not exist
 LINE 2:     RETURN acos()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN atan()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_atan() does not exist
+ERROR:  function ag_catalog.atan() does not exist
 LINE 2:     RETURN atan()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN atan2()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_atan2() does not exist
+ERROR:  function ag_catalog.atan2() does not exist
 LINE 2:     RETURN atan2()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -4302,37 +4314,41 @@ SELECT * FROM cypher('expr', $$
     RETURN atan2(null)
 $$) AS (results agtype);
 ERROR:  atan2() invalid number of arguments
-SELECT * FROM age_asin('0');
-ERROR:  asin() unsupported argument type 25
-SELECT * FROM age_acos('0');
-ERROR:  acos() unsupported argument type 25
-SELECT * FROM age_atan('0');
-ERROR:  atan() unsupported argument type 25
-SELECT * FROM age_atan2('0', 1);
-ERROR:  atan2() unsupported argument type 25
-SELECT * FROM age_atan2(1, '0');
-ERROR:  atan2() unsupported argument type 25
-SELECT * FROM age_asin();
-ERROR:  function age_asin() does not exist
-LINE 1: SELECT * FROM age_asin();
+SELECT * FROM asin('"0"'::agtype);
+ERROR:  asin() unsupported argument agtype 1
+SELECT * FROM acos('"0"'::agtype);
+ERROR:  acos() unsupported argument agtype 1
+SELECT * FROM atan('"0"'::agtype);
+ERROR:  atan() unsupported argument agtype 1
+SELECT * FROM atan2('"0"'::agtype, 1);
+ERROR:  atan2() unsupported argument agtype 1
+SELECT * FROM atan2(1, '0');
+      atan2      
+-----------------
+ 1.5707963267949
+(1 row)
+
+SELECT * FROM asin();
+ERROR:  function asin() does not exist
+LINE 1: SELECT * FROM asin();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_acos();
-ERROR:  function age_acos() does not exist
-LINE 1: SELECT * FROM age_acos();
+SELECT * FROM acos();
+ERROR:  function acos() does not exist
+LINE 1: SELECT * FROM acos();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_atan();
-ERROR:  function age_atan() does not exist
-LINE 1: SELECT * FROM age_atan();
+SELECT * FROM atan();
+ERROR:  function atan() does not exist
+LINE 1: SELECT * FROM atan();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_atan2();
-ERROR:  function age_atan2() does not exist
-LINE 1: SELECT * FROM age_atan2();
+SELECT * FROM atan2();
+ERROR:  function atan2() does not exist
+LINE 1: SELECT * FROM atan2();
                       ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT * FROM age_atan2(1);
+SELECT * FROM atan2(1);
 ERROR:  atan2() invalid number of arguments
 --
 -- pi
@@ -4389,14 +4405,14 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN pi(null)
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_pi(agtype) does not exist
+ERROR:  function ag_catalog.pi(agtype) does not exist
 LINE 2:     RETURN pi(null)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN pi(1)
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_pi(agtype) does not exist
+ERROR:  function ag_catalog.pi(agtype) does not exist
 LINE 2:     RETURN pi(1)
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -4488,14 +4504,14 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN radians()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_radians() does not exist
+ERROR:  function ag_catalog.radians() does not exist
 LINE 2:     RETURN radians()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN degrees()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_degrees() does not exist
+ERROR:  function ag_catalog.degrees() does not exist
 LINE 2:     RETURN degrees()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -4779,35 +4795,35 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN abs()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_abs() does not exist
+ERROR:  function ag_catalog.abs() does not exist
 LINE 2:     RETURN abs()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN ceil()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_ceil() does not exist
+ERROR:  function ag_catalog.ceil() does not exist
 LINE 2:     RETURN ceil()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN floor()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_floor() does not exist
+ERROR:  function ag_catalog.floor() does not exist
 LINE 2:     RETURN floor()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN round()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_round() does not exist
+ERROR:  function ag_catalog.round() does not exist
 LINE 2:     RETURN round()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('expr', $$
     RETURN sign()
 $$) AS (results agtype);
-ERROR:  function ag_catalog.age_sign() does not exist
+ERROR:  function ag_catalog.sign() does not exist
 LINE 2:     RETURN sign()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -4927,14 +4943,14 @@ $$) as (result agtype);
 SELECT * from cypher('expr', $$
     RETURN log()
 $$) as (result agtype);
-ERROR:  function ag_catalog.age_log() does not exist
+ERROR:  function ag_catalog.log() does not exist
 LINE 2:     RETURN log()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * from cypher('expr', $$
     RETURN log10()
 $$) as (result agtype);
-ERROR:  function ag_catalog.age_log10() does not exist
+ERROR:  function ag_catalog.log10() does not exist
 LINE 2:     RETURN log10()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -4989,7 +5005,7 @@ $$) as (result agtype);
 SELECT * from cypher('expr', $$
     RETURN exp()
 $$) as (result agtype);
-ERROR:  function ag_catalog.age_exp() does not exist
+ERROR:  function ag_catalog.exp() does not exist
 LINE 2:     RETURN exp()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -5045,7 +5061,7 @@ $$) as (result agtype);
 SELECT * from cypher('expr', $$
     RETURN sqrt()
 $$) as (result agtype);
-ERROR:  function ag_catalog.age_sqrt() does not exist
+ERROR:  function ag_catalog.sqrt() does not exist
 LINE 2:     RETURN sqrt()
                    ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -5065,7 +5081,7 @@ $$) as (result agtype);
 (1 row)
 
 SELECT * from cypher('expr', $$
-    RETURN ag_catalog.age_sqrt(25)
+    RETURN ag_catalog.sqrt(25)
 $$) as (result agtype);
  result 
 --------
@@ -5105,16 +5121,16 @@ LINE 2:     RETURN something.pg_catalog.sqrt("1"::pg_float8)
                    ^
 -- should fail do to schema but using a reserved_keyword
 SELECT * from cypher('expr', $$
-    RETURN distinct.age_sqrt(25)
+    RETURN distinct.sqrt(25)
 $$) as (result agtype);
 ERROR:  schema "distinct" does not exist
-LINE 2:     RETURN distinct.age_sqrt(25)
+LINE 2:     RETURN distinct.sqrt(25)
                    ^
 SELECT * from cypher('expr', $$
-    RETURN contains.age_sqrt(25)
+    RETURN contains.sqrt(25)
 $$) as (result agtype);
 ERROR:  schema "contains" does not exist
-LINE 2:     RETURN contains.age_sqrt(25)
+LINE 2:     RETURN contains.sqrt(25)
                    ^
 --
 -- aggregate functions avg(), sum(), count(), & count(*)
@@ -5234,17 +5250,17 @@ SELECT * FROM cypher('UCSC', $$ RETURN count(NULL) $$) AS (count agtype);
 
 -- should fail
 SELECT * FROM cypher('UCSC', $$ RETURN avg() $$) AS (avg agtype);
-ERROR:  function ag_catalog.age_avg() does not exist
+ERROR:  function ag_catalog.avg() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN avg() $$) AS (avg agt...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('UCSC', $$ RETURN sum() $$) AS (sum agtype);
-ERROR:  function ag_catalog.age_sum() does not exist
+ERROR:  function ag_catalog.sum() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN sum() $$) AS (sum agt...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('UCSC', $$ RETURN count() $$) AS (count agtype);
-ERROR:  ag_catalog.age_count(*) must be used to call a parameterless aggregate function
+ERROR:  ag_catalog.count(*) must be used to call a parameterless aggregate function
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN count() $$) AS (count...
                                                ^
 --
@@ -5279,30 +5295,30 @@ AS (min agtype, max agtype, count agtype, count_star agtype);
  "95060" | 96062 | 5     | 9
 (1 row)
 
-CREATE TABLE min_max_tbl (oid oid);
-insert into min_max_tbl VALUES (16), (17188), (1000), (869);
-SELECT age_min(oid::int), age_max(oid::int) FROM min_max_tbl;
- age_min | age_max 
----------+---------
- 16      | 17188
+CREATE TABLE min_max_tbl (id agtype);
+insert into min_max_tbl VALUES ('16'), ('17188'), ('1000'), ('869');
+SELECT min(id), max(id) FROM min_max_tbl;
+ min |  max  
+-----+-------
+ 16  | 17188
 (1 row)
 
-SELECT age_min(oid::int::float), age_max(oid::int::float) FROM min_max_tbl;
- age_min | age_max 
----------+---------
- 16.0    | 17188.0
+SELECT min(tofloat(id)), max(tofloat(id)) FROM min_max_tbl;
+ min  |   max   
+------+---------
+ 16.0 | 17188.0
 (1 row)
 
-SELECT age_min(oid::int::float::numeric), age_max(oid::int::float::numeric) FROM min_max_tbl;
-   age_min   |    age_max     
+SELECT min(agtype_typecast_numeric(id)), max( agtype_typecast_numeric(id)) FROM min_max_tbl;
+     min     |      max       
 -------------+----------------
  16::numeric | 17188::numeric
 (1 row)
 
-SELECT age_min(oid::text), age_max(oid::text) FROM min_max_tbl;
- age_min | age_max 
----------+---------
- "1000"  | "869"
+SELECT min(tostring(id)), max(tostring(id))  FROM min_max_tbl;
+  min   |  max  
+--------+-------
+ "1000" | "869"
 (1 row)
 
 DROP TABLE min_max_tbl;
@@ -5319,49 +5335,49 @@ SELECT * FROM cypher('UCSC', $$ RETURN max(NULL) $$) AS (max agtype);
  
 (1 row)
 
-SELECT age_min(NULL);
- age_min 
----------
+SELECT min(NULL::agtype);
+ min 
+-----
  
 (1 row)
 
-SELECT age_min(agtype_in('null'));
- age_min 
----------
+SELECT min(agtype_in('null'));
+ min 
+-----
  
 (1 row)
 
-SELECT age_max(NULL);
- age_max 
----------
+SELECT max(NULL::agtype);
+ max 
+-----
  
 (1 row)
 
-SELECT age_max(agtype_in('null'));
- age_max 
----------
+SELECT max(agtype_in('null'));
+ max 
+-----
  
 (1 row)
 
 -- should fail
 SELECT * FROM cypher('UCSC', $$ RETURN min() $$) AS (min agtype);
-ERROR:  function ag_catalog.age_min() does not exist
+ERROR:  function ag_catalog.min() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN min() $$) AS (min agt...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('UCSC', $$ RETURN max() $$) AS (max agtype);
-ERROR:  function ag_catalog.age_max() does not exist
+ERROR:  function ag_catalog.max() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN max() $$) AS (max agt...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT age_min();
-ERROR:  function age_min() does not exist
-LINE 1: SELECT age_min();
+SELECT min();
+ERROR:  function min() does not exist
+LINE 1: SELECT min();
                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT age_min();
-ERROR:  function age_min() does not exist
-LINE 1: SELECT age_min();
+SELECT min();
+ERROR:  function min() does not exist
+LINE 1: SELECT min();
                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 --
@@ -5389,12 +5405,12 @@ SELECT * FROM cypher('UCSC', $$ RETURN stDevP(NULL) $$) AS (stDevP agtype);
 
 -- should fail
 SELECT * FROM cypher('UCSC', $$ RETURN stDev() $$) AS (stDev agtype);
-ERROR:  function ag_catalog.age_stdev() does not exist
+ERROR:  function ag_catalog.stdev() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN stDev() $$) AS (stDev...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT * FROM cypher('UCSC', $$ RETURN stDevP() $$) AS (stDevP agtype);
-ERROR:  function ag_catalog.age_stdevp() does not exist
+ERROR:  function ag_catalog.stdevp() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN stDevP() $$) AS (stDe...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
@@ -5485,7 +5501,7 @@ SELECT * FROM cypher('UCSC', $$ MATCH (u) WHERE u.name =~ "doesn't exist" RETURN
 
 -- should fail
 SELECT * FROM cypher('UCSC', $$ RETURN collect() $$) AS (collect agtype);
-ERROR:  function ag_catalog.age_collect() does not exist
+ERROR:  function ag_catalog.collect() does not exist
 LINE 1: SELECT * FROM cypher('UCSC', $$ RETURN collect() $$) AS (col...
                                                ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.

--- a/regress/sql/agtype.sql
+++ b/regress/sql/agtype.sql
@@ -676,33 +676,33 @@ SELECT _agtype_build_path(
 --
 -- id, startid, endid
 --
-SELECT age_id(_agtype_build_vertex('1'::graphid, $$label_name$$, agtype_build_map()));
-SELECT age_id(_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
+SELECT id(_agtype_build_vertex('1'::graphid, $$label_name$$, agtype_build_map()));
+SELECT id(_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
 			  $$label_name$$, agtype_build_map('id', 2)));
 
-SELECT age_start_id(_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
+SELECT start_id(_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
 			  $$label_name$$, agtype_build_map('id', 2)));
 
-SELECT age_end_id(_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
+SELECT end_id(_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
 			  $$label_name$$, agtype_build_map('id', 2)));
 
 
-SELECT age_id(_agtype_build_path(
+SELECT id(_agtype_build_path(
 	_agtype_build_vertex('2'::graphid, $$label_name$$, agtype_build_map()),
 	_agtype_build_edge('1'::graphid, '2'::graphid, '3'::graphid,
 			  $$label$$, agtype_build_map('id', 2)),
 	_agtype_build_vertex('3'::graphid, $$label$$, agtype_build_map('id', 2))
 ));
 
-SELECT age_id(agtype_in('1'));
+SELECT id(agtype_in('1'));
 
-SELECT age_id(NULL);
-SELECT age_start_id(NULL);
-SELECT age_end_id(NULL);
+SELECT id(NULL);
+SELECT start_id(NULL);
+SELECT end_id(NULL);
 
-SELECT age_id(agtype_in('null'));
-SELECT age_start_id(agtype_in('null'));
-SELECT age_end_id(agtype_in('null'));
+SELECT id(agtype_in('null'));
+SELECT start_id(agtype_in('null'));
+SELECT end_id(agtype_in('null'));
 
 SELECT agtype_contains('{"id": 1}','{"id": 1}');
 SELECT agtype_contains('{"id": 1}','{"id": 2}');

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -573,7 +573,7 @@ SELECT * FROM cypher('type_coercion', $$
 $$) AS (i bigint);
 
 --
--- Test typecasting '::' transform and execution logic
+-- Test typecasting '::' 
 --
 
 --
@@ -974,7 +974,7 @@ $$) AS (label agtype);
 SELECT * FROM cypher('expr', $$
     RETURN label(NULL)
 $$) AS (label agtype);
-SELECT ag_catalog.age_label(NULL);
+SELECT ag_catalog.label(NULL);
 -- should error
 SELECT * FROM cypher('expr', $$
     MATCH p=()-[]->() RETURN label(p)
@@ -1212,29 +1212,29 @@ $$) AS (length agtype);
 --
 
 -- PG types
-SELECT * FROM age_toString(3);
-SELECT * FROM age_toString(3.14);
-SELECT * FROM age_toString(3.14::float);
-SELECT * FROM age_toString(3.14::numeric);
-SELECT * FROM age_toString(true);
-SELECT * FROM age_toString(false);
-SELECT * FROM age_toString('a string');
-SELECT * FROM age_toString('a cstring'::cstring);
-SELECT * FROM age_toString('a text string'::text);
+SELECT * FROM toString(3);
+SELECT * FROM toString(3.14);
+SELECT * FROM toString(3.14::float);
+SELECT * FROM toString(3.14::numeric);
+SELECT * FROM toString(true);
+SELECT * FROM toString(false);
+SELECT * FROM toString('a string');
+SELECT * FROM toString('a cstring'::cstring);
+SELECT * FROM toString('a text string'::text);
 -- agtypes
-SELECT * FROM age_toString(agtype_in('3'));
-SELECT * FROM age_toString(agtype_in('3.14'));
-SELECT * FROM age_toString(agtype_in('3.14::float'));
-SELECT * FROM age_toString(agtype_in('3.14::numeric'));
-SELECT * FROM age_toString(agtype_in('true'));
-SELECT * FROM age_toString(agtype_in('false'));
-SELECT * FROM age_toString(agtype_in('"a string"'));
+SELECT * FROM toString(agtype_in('3'));
+SELECT * FROM toString(agtype_in('3.14'));
+SELECT * FROM toString(agtype_in('3.14::float'));
+SELECT * FROM toString(agtype_in('3.14::numeric'));
+SELECT * FROM toString(agtype_in('true'));
+SELECT * FROM toString(agtype_in('false'));
+SELECT * FROM toString(agtype_in('"a string"'));
 SELECT * FROM cypher('expr', $$ RETURN toString(3.14::numeric) $$) AS (results agtype);
 -- should return null
-SELECT * FROM age_toString(NULL);
-SELECT * FROM age_toString(agtype_in(null));
+SELECT * FROM toString(NULL);
+SELECT * FROM toString(agtype_in(null));
 -- should fail
-SELECT * FROM age_toString();
+SELECT * FROM toString();
 SELECT * FROM cypher('expr', $$ RETURN toString() $$) AS (results agtype);
 
 --
@@ -1243,16 +1243,16 @@ SELECT * FROM cypher('expr', $$ RETURN toString() $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN reverse("gnirts a si siht")
 $$) AS (results agtype);
-SELECT * FROM age_reverse('gnirts a si siht');
-SELECT * FROM age_reverse('gnirts a si siht'::text);
-SELECT * FROM age_reverse('gnirts a si siht'::cstring);
+SELECT * FROM reverse('gnirts a si siht');
+SELECT * FROM reverse('gnirts a si siht'::text);
+SELECT * FROM reverse('gnirts a si siht'::cstring);
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN reverse(null)
 $$) AS (results agtype);
-SELECT * FROM age_reverse(null);
+SELECT * FROM reverse(null);
 -- should return error
-SELECT * FROM age_reverse([4923, 'abc', 521, NULL, 487]);
+SELECT * FROM reverse([4923, 'abc', 521, NULL, 487]);
 -- Should return the reversed list
 SELECT * FROM cypher('expr', $$
     RETURN reverse([4923, 'abc', 521, NULL, 487])
@@ -1286,15 +1286,15 @@ $$) as (u agtype);
 SELECT * FROM cypher('expr', $$
     RETURN reverse(true)
 $$) AS (results agtype);
-SELECT * FROM age_reverse(true);
+SELECT * FROM reverse(true);
 SELECT * FROM cypher('expr', $$
     RETURN reverse(3.14)
 $$) AS (results agtype);
-SELECT * FROM age_reverse(3.14);
+SELECT * FROM reverse(3.14);
 SELECT * FROM cypher('expr', $$
     RETURN reverse()
 $$) AS (results agtype);
-SELECT * FROM age_reverse();
+SELECT * FROM reverse();
 
 --
 -- toUpper() and toLower()
@@ -1305,10 +1305,10 @@ $$) AS (toUpper agtype);
 SELECT * FROM cypher('expr', $$
     RETURN toLower('TO LOWERCASE')
 $$) AS (toLower agtype);
-SELECT * FROM age_toupper('text'::text);
-SELECT * FROM age_toupper('cstring'::cstring);
-SELECT * FROM age_tolower('TEXT'::text);
-SELECT * FROM age_tolower('CSTRING'::cstring);
+SELECT * FROM toupper('text'::text);
+SELECT * FROM toupper('cstring'::cstring);
+SELECT * FROM tolower('TEXT'::text);
+SELECT * FROM tolower('CSTRING'::cstring);
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN toUpper(null)
@@ -1316,8 +1316,8 @@ $$) AS (toUpper agtype);
 SELECT * FROM cypher('expr', $$
     RETURN toLower(null)
 $$) AS (toLower agtype);
-SELECT * FROM age_toupper(null);
-SELECT * FROM age_tolower(null);
+SELECT * FROM toupper(null);
+SELECT * FROM tolower(null);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN toUpper(true)
@@ -1331,8 +1331,8 @@ $$) AS (toLower agtype);
 SELECT * FROM cypher('expr', $$
     RETURN toLower()
 $$) AS (toLower agtype);
-SELECT * FROM age_toupper();
-SELECT * FROM age_tolower();
+SELECT * FROM toupper();
+SELECT * FROM tolower();
 
 --
 -- lTrim(), rTrim(), trim()
@@ -1347,9 +1347,9 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN trim("  string   ")
 $$) AS (results agtype);
-SELECT * FROM age_ltrim('  string   ');
-SELECT * FROM age_rtrim('  string   ');
-SELECT * FROM age_trim('  string   ');
+SELECT * FROM ltrim('  string   ');
+SELECT * FROM rtrim('  string   ');
+SELECT * FROM trim('  string   ');
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN lTrim(null)
@@ -1360,9 +1360,9 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN trim(null)
 $$) AS (results agtype);
-SELECT * FROM age_ltrim(null);
-SELECT * FROM age_rtrim(null);
-SELECT * FROM age_trim(null);
+SELECT * FROM ltrim(null);
+SELECT * FROM rtrim(null);
+SELECT * FROM trim(null);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN lTrim(true)
@@ -1383,9 +1383,9 @@ SELECT * FROM cypher('expr', $$
     RETURN trim()
 $$) AS (results agtype);
 
-SELECT * FROM age_ltrim();
-SELECT * FROM age_rtrim();
-SELECT * FROM age_trim();
+SELECT * FROM ltrim();
+SELECT * FROM rtrim();
+SELECT * FROM trim();
 
 --
 -- left(), right(), & substring()
@@ -1406,8 +1406,8 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN left(null, null)
 $$) AS (results agtype);
-SELECT * FROM age_left(null, 1);
-SELECT * FROM age_left(null, null);
+SELECT * FROM left(null, 1);
+SELECT * FROM left(null, null);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN left("123456789", null)
@@ -1418,9 +1418,9 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN left()
 $$) AS (results agtype);
-SELECT * FROM age_left('123456789', null);
-SELECT * FROM age_left('123456789', -1);
-SELECT * FROM age_left();
+SELECT * FROM left('"123456789"'::agtype, null);
+SELECT * FROM left('"123456789"'::agtype, -1);
+SELECT * FROM left();
 --right()
 SELECT * FROM cypher('expr', $$
     RETURN right("123456789", 1)
@@ -1438,8 +1438,8 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN right(null, null)
 $$) AS (results agtype);
-SELECT * FROM age_right(null, 1);
-SELECT * FROM age_right(null, null);
+SELECT * FROM right(null, 1);
+SELECT * FROM right(null, null);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN right("123456789", null)
@@ -1450,9 +1450,9 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN right()
 $$) AS (results agtype);
-SELECT * FROM age_right('123456789', null);
-SELECT * FROM age_right('123456789', -1);
-SELECT * FROM age_right();
+SELECT * FROM right('123456789', null);
+SELECT * FROM right('123456789', -1);
+SELECT * FROM right();
 -- substring()
 SELECT * FROM cypher('expr', $$
     RETURN substring("0123456789", 0, 1)
@@ -1466,8 +1466,8 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN substring("0123456789", 0)
 $$) AS (results agtype);
-SELECT * FROM age_substring('0123456789', 3, 2);
-SELECT * FROM age_substring('0123456789', 1);
+SELECT * FROM substring('0123456789', 3, 2);
+SELECT * FROM substring('0123456789', 1);
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN substring(null, null, null)
@@ -1478,9 +1478,9 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN substring(null, 1)
 $$) AS (results agtype);
-SELECT * FROM age_substring(null, null, null);
-SELECT * FROM age_substring(null, null);
-SELECT * FROM age_substring(null, 1);
+SELECT * FROM substring(null, null, null);
+SELECT * FROM substring(null, null);
+SELECT * FROM substring(null, 1);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN substring("123456789", null)
@@ -1494,10 +1494,10 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN substring("123456789")
 $$) AS (results agtype);
-SELECT * FROM age_substring('123456789', null);
-SELECT * FROM age_substring('123456789', 0, -1);
-SELECT * FROM age_substring('123456789', -1);
-SELECT * FROM age_substring();
+SELECT * FROM substring('123456789', null);
+SELECT * FROM substring('123456789', 0, -1);
+SELECT * FROM substring('123456789', -1);
+SELECT * FROM substring();
 
 --
 -- split()
@@ -1530,9 +1530,9 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN split(null, ",")
 $$) AS (results agtype);
-SELECT * FROM age_split(null, null);
-SELECT * FROM age_split('a,b,c,d,e,f', null);
-SELECT * FROM age_split(null, ',');
+SELECT * FROM split(null, null);
+SELECT * FROM split('a,b,c,d,e,f', null);
+SELECT * FROM split(null, ',');
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN split(123456789, ",")
@@ -1546,10 +1546,10 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN split()
 $$) AS (results agtype);
-SELECT * FROM age_split(123456789, ',');
-SELECT * FROM age_split('a,b,c,d,e,f', -1);
-SELECT * FROM age_split('a,b,c,d,e,f');
-SELECT * FROM age_split();
+SELECT * FROM split(123456789, ',');
+SELECT * FROM split('a,b,c,d,e,f', -1);
+SELECT * FROM split('a,b,c,d,e,f');
+SELECT * FROM split();
 
 --
 -- replace()
@@ -1588,12 +1588,12 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN replace("", "Hello", "Mellow")
 $$) AS (results agtype);
-SELECT * FROM age_replace(null, null, null);
-SELECT * FROM age_replace('Hello', null, null);
-SELECT * FROM age_replace('Hello', '', null);
-SELECT * FROM age_replace('', '', '');
-SELECT * FROM age_replace('Hello', 'Hello', '');
-SELECT * FROM age_replace('', 'Hello', 'Mellow');
+SELECT * FROM replace(null, null, null);
+SELECT * FROM replace('Hello', null, null);
+SELECT * FROM replace('Hello', '', null);
+SELECT * FROM replace('', '', '');
+SELECT * FROM replace('Hello', 'Hello', '');
+SELECT * FROM replace('', 'Hello', 'Mellow');
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN replace()
@@ -1610,11 +1610,11 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN replace("Hello", 1, "e")
 $$) AS (results agtype);
-SELECT * FROM age_replace();
-SELECT * FROM age_replace(null);
-SELECT * FROM age_replace(null, null);
-SELECT * FROM age_replace('Hello', 'e', 1);
-SELECT * FROM age_replace('Hello', 1, 'E');
+SELECT * FROM replace();
+SELECT * FROM replace(null);
+SELECT * FROM replace(null, null);
+SELECT * FROM replace('Hello', 'e', 1);
+SELECT * FROM replace('Hello', 1, 'E');
 
 --
 -- sin, cos, tan, cot
@@ -1631,10 +1631,10 @@ $$) AS (results agtype), tan(3.1415);
 SELECT cot = results FROM cypher('expr', $$
     RETURN cot(3.1415)
 $$) AS (results agtype), cot(3.1415);
-SELECT sin = age_sin FROM sin(3.1415), age_sin(3.1415);
-SELECT cos = age_cos FROM cos(3.1415), age_cos(3.1415);
-SELECT tan = age_tan FROM tan(3.1415), age_tan(3.1415);
-SELECT cot = age_cot FROM cot(3.1415), age_cot(3.1415);
+SELECT agtype_sin = float_sin FROM sin(3.1415::float8) as float_sin, sin('3.1415'::agtype) AS agtype_sin;
+SELECT agtype_cos = float_cos FROM cos(3.1415::float8) as float_cos, cos('3.1415'::agtype) AS agtype_cos;
+SELECT agtype_tan = float_tan FROM tan(3.1415::float8) as float_tan, tan('3.1415'::agtype) AS agtype_tan;
+SELECT agtype_cot = float_cot FROM cot(3.1415::float8) as float_cot, cot('3.1415'::agtype) AS agtype_cot;
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN sin(null)
@@ -1648,10 +1648,10 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN cot(null)
 $$) AS (results agtype);
-SELECT * FROM age_sin(null);
-SELECT * FROM age_cos(null);
-SELECT * FROM age_tan(null);
-SELECT * FROM age_cot(null);
+SELECT * FROM sin(null::agtype);
+SELECT * FROM cos(null::agtype);
+SELECT * FROM tan(null::agtype);
+SELECT * FROM cot(null::agtype);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN sin("0")
@@ -1677,14 +1677,14 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN cot()
 $$) AS (results agtype);
-SELECT * FROM age_sin('0');
-SELECT * FROM age_cos('0');
-SELECT * FROM age_tan('0');
-SELECT * FROM age_cot('0');
-SELECT * FROM age_sin();
-SELECT * FROM age_cos();
-SELECT * FROM age_tan();
-SELECT * FROM age_cot();
+SELECT * FROM sin('"0"'::agtype);
+SELECT * FROM cos('"0"'::agtype);
+SELECT * FROM tan('"0"'::agtype);
+SELECT * FROM cot('"0"'::agtype);
+SELECT * FROM sin();
+SELECT * FROM cos();
+SELECT * FROM tan();
+SELECT * FROM cot();
 
 --
 -- Arc functions: asin, acos, atan, & atan2
@@ -1701,10 +1701,10 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN atan2(1, 1)*4
 $$) AS (results agtype);
-SELECT * FROM asin(1), age_asin(1);
-SELECT * FROM acos(0), age_acos(0);
-SELECT * FROM atan(1), age_atan(1);
-SELECT * FROM atan2(1, 1), age_atan2(1, 1);
+SELECT * FROM asin(1::int), asin('1'::agtype) as agtype_asin;
+SELECT * FROM acos(0), acos('0'::agtype) as agtype_acos;
+SELECT * FROM atan(1), atan('1'::agtype) as agtype_atan;
+SELECT * FROM atan2(1, 1), atan2('1'::agtype, '1'::agtype) as agtype_atan;
 -- should return null
 SELECT * FROM cypher('expr', $$
     RETURN asin(1.1)
@@ -1736,12 +1736,12 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN atan2(1, null)
 $$) AS (results agtype);
-SELECT * FROM age_asin(null);
-SELECT * FROM age_acos(null);
-SELECT * FROM age_atan(null);
-SELECT * FROM age_atan2(null, null);
-SELECT * FROM age_atan2(1, null);
-SELECT * FROM age_atan2(null, 1);
+SELECT * FROM asin(null::agtype);
+SELECT * FROM acos(null::agtype);
+SELECT * FROM atan(null::agtype);
+SELECT * FROM atan2(null, null::agtype);
+SELECT * FROM atan2(1, null::agtype);
+SELECT * FROM atan2(null::agtype, 1);
 -- should fail
 SELECT * FROM cypher('expr', $$
     RETURN asin("0")
@@ -1773,16 +1773,16 @@ $$) AS (results agtype);
 SELECT * FROM cypher('expr', $$
     RETURN atan2(null)
 $$) AS (results agtype);
-SELECT * FROM age_asin('0');
-SELECT * FROM age_acos('0');
-SELECT * FROM age_atan('0');
-SELECT * FROM age_atan2('0', 1);
-SELECT * FROM age_atan2(1, '0');
-SELECT * FROM age_asin();
-SELECT * FROM age_acos();
-SELECT * FROM age_atan();
-SELECT * FROM age_atan2();
-SELECT * FROM age_atan2(1);
+SELECT * FROM asin('"0"'::agtype);
+SELECT * FROM acos('"0"'::agtype);
+SELECT * FROM atan('"0"'::agtype);
+SELECT * FROM atan2('"0"'::agtype, 1);
+SELECT * FROM atan2(1, '0');
+SELECT * FROM asin();
+SELECT * FROM acos();
+SELECT * FROM atan();
+SELECT * FROM atan2();
+SELECT * FROM atan2(1);
 
 --
 -- pi
@@ -2114,7 +2114,7 @@ SELECT * from cypher('expr', $$
     RETURN pg_catalog.sqrt(25::pg_float8)
 $$) as (result agtype);
 SELECT * from cypher('expr', $$
-    RETURN ag_catalog.age_sqrt(25)
+    RETURN ag_catalog.sqrt(25)
 $$) as (result agtype);
 -- should return null
 SELECT * from cypher('expr', $$
@@ -2135,10 +2135,10 @@ SELECT * from cypher('expr', $$
 $$) as (result agtype);
 -- should fail do to schema but using a reserved_keyword
 SELECT * from cypher('expr', $$
-    RETURN distinct.age_sqrt(25)
+    RETURN distinct.sqrt(25)
 $$) as (result agtype);
 SELECT * from cypher('expr', $$
-    RETURN contains.age_sqrt(25)
+    RETURN contains.sqrt(25)
 $$) as (result agtype);
 
 --
@@ -2183,27 +2183,27 @@ AS (min agtype, max agtype, count agtype, count_star agtype);
 -- check that min() & max() can work against mixed types
 SELECT * FROM cypher('UCSC', $$ MATCH (u) RETURN min(u.zip), max(u.zip), count(u.zip), count(*) $$)
 AS (min agtype, max agtype, count agtype, count_star agtype);
-CREATE TABLE min_max_tbl (oid oid);
-insert into min_max_tbl VALUES (16), (17188), (1000), (869);
+CREATE TABLE min_max_tbl (id agtype);
+insert into min_max_tbl VALUES ('16'), ('17188'), ('1000'), ('869');
 
-SELECT age_min(oid::int), age_max(oid::int) FROM min_max_tbl;
-SELECT age_min(oid::int::float), age_max(oid::int::float) FROM min_max_tbl;
-SELECT age_min(oid::int::float::numeric), age_max(oid::int::float::numeric) FROM min_max_tbl;
-SELECT age_min(oid::text), age_max(oid::text) FROM min_max_tbl;
+SELECT min(id), max(id) FROM min_max_tbl;
+SELECT min(tofloat(id)), max(tofloat(id)) FROM min_max_tbl;
+SELECT min(agtype_typecast_numeric(id)), max( agtype_typecast_numeric(id)) FROM min_max_tbl;
+SELECT min(tostring(id)), max(tostring(id))  FROM min_max_tbl;
 
 DROP TABLE min_max_tbl;
 -- should return null
 SELECT * FROM cypher('UCSC', $$ RETURN min(NULL) $$) AS (min agtype);
 SELECT * FROM cypher('UCSC', $$ RETURN max(NULL) $$) AS (max agtype);
-SELECT age_min(NULL);
-SELECT age_min(agtype_in('null'));
-SELECT age_max(NULL);
-SELECT age_max(agtype_in('null'));
+SELECT min(NULL::agtype);
+SELECT min(agtype_in('null'));
+SELECT max(NULL::agtype);
+SELECT max(agtype_in('null'));
 -- should fail
 SELECT * FROM cypher('UCSC', $$ RETURN min() $$) AS (min agtype);
 SELECT * FROM cypher('UCSC', $$ RETURN max() $$) AS (max agtype);
-SELECT age_min();
-SELECT age_min();
+SELECT min();
+SELECT min();
 --
 -- aggregate functions stDev() & stDevP()
 --

--- a/src/backend/parser/cypher_clause.c
+++ b/src/backend/parser/cypher_clause.c
@@ -1075,8 +1075,8 @@ static Query *transform_cypher_delete(cypher_parsestate *cpstate,
 /*
  * transform_cypher_unwind
  *      It contains logic to convert the form of an array into a row. Here, we
- *      are simply calling `age_unnest` function, and the actual transformation
- *      is handled by `age_unnest` function.
+ *      are simply calling `unnest` function, and the actual transformation
+ *      is handled by `unnest` function.
  */
 static Query *transform_cypher_unwind(cypher_parsestate *cpstate,
                                       cypher_clause *clause)
@@ -1117,7 +1117,7 @@ static Query *transform_cypher_unwind(cypher_parsestate *cpstate,
 
     expr = transform_cypher_expr(cpstate, self->target->val, EXPR_KIND_SELECT_TARGET);
 
-    unwind = makeFuncCall(list_make1(makeString("age_unnest")), NIL, COERCE_SQL_SYNTAX, -1);
+    unwind = makeFuncCall(list_make2(makeString("ag_catalog"),makeString("unnest")), NIL, COERCE_SQL_SYNTAX, -1);
 
 
     old_expr_kind = pstate->p_expr_kind;

--- a/src/backend/parser/cypher_gram.y
+++ b/src/backend/parser/cypher_gram.y
@@ -1317,7 +1317,7 @@ expr:
         }
     | expr EQ_TILDE expr
         {
-            $$ = (Node *)makeFuncCall(list_make1(makeString("eq_tilde")),
+            $$ = (Node *)makeFuncCall(list_make1(makeString("agtype_eq_tilde")),
                                       list_make2($1, $3), COERCE_SQL_SYNTAX, @2);
         }
     | expr_atom
@@ -2308,7 +2308,7 @@ static cypher_relationship *build_VLE_relation(List *left_arg,
     args = lappend(args, make_int_const(unique_number, -1));
 
     /* build the VLE function node */
-    cr->varlen = (Node *)makeFuncCall(list_make1(makeString("vle")), args, COERCE_SQL_SYNTAX, cr_location); 
+    cr->varlen = (Node *)makeFuncCall(list_make1(makeString("age_vle")), args, COERCE_SQL_SYNTAX, cr_location); 
 
     return cr;
 }

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -3985,9 +3985,9 @@ Datum agtype_typecast_path(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(path.res));
 }
 
-PG_FUNCTION_INFO_V1(age_id);
+PG_FUNCTION_INFO_V1(agtype_id);
 
-Datum age_id(PG_FUNCTION_ARGS)
+Datum agtype_id(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_object = NULL;
@@ -4023,9 +4023,9 @@ Datum age_id(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_start_id);
+PG_FUNCTION_INFO_V1(agtype_start_id);
 
-Datum age_start_id(PG_FUNCTION_ARGS)
+Datum agtype_start_id(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_object = NULL;
@@ -4061,9 +4061,9 @@ Datum age_start_id(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_end_id);
+PG_FUNCTION_INFO_V1(agtype_end_id);
 
-Datum age_end_id(PG_FUNCTION_ARGS)
+Datum agtype_end_id(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_object = NULL;
@@ -4263,9 +4263,9 @@ static Datum get_vertex(const char *graph, const char *vertex_label,
     return result;
 }
 
-PG_FUNCTION_INFO_V1(age_startnode);
+PG_FUNCTION_INFO_V1(agtype_startnode);
 
-Datum age_startnode(PG_FUNCTION_ARGS)
+Datum agtype_startnode(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_object = NULL;
@@ -4328,9 +4328,9 @@ Datum age_startnode(PG_FUNCTION_ARGS)
     return result;
 }
 
-PG_FUNCTION_INFO_V1(age_endnode);
+PG_FUNCTION_INFO_V1(agtype_endnode);
 
-Datum age_endnode(PG_FUNCTION_ARGS)
+Datum agtype_endnode(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_object = NULL;
@@ -4393,9 +4393,9 @@ Datum age_endnode(PG_FUNCTION_ARGS)
     return result;
 }
 
-PG_FUNCTION_INFO_V1(age_head);
+PG_FUNCTION_INFO_V1(agtype_head);
 
-Datum age_head(PG_FUNCTION_ARGS)
+Datum agtype_head(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_result = NULL;
@@ -4427,9 +4427,9 @@ Datum age_head(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_last);
+PG_FUNCTION_INFO_V1(agtype_last);
 
-Datum age_last(PG_FUNCTION_ARGS)
+Datum agtype_last(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_result = NULL;
@@ -4461,9 +4461,9 @@ Datum age_last(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_properties);
+PG_FUNCTION_INFO_V1(agtype_properties);
 
-Datum age_properties(PG_FUNCTION_ARGS)
+Datum agtype_properties(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_object = NULL;
@@ -4499,9 +4499,9 @@ Datum age_properties(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_length);
+PG_FUNCTION_INFO_V1(agtype_length);
 
-Datum age_length(PG_FUNCTION_ARGS)
+Datum agtype_length(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_path = NULL;
@@ -4535,9 +4535,9 @@ Datum age_length(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_toboolean);
+PG_FUNCTION_INFO_V1(agtype_toboolean);
 
-Datum age_toboolean(PG_FUNCTION_ARGS)
+Datum agtype_toboolean(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -4633,9 +4633,9 @@ Datum age_toboolean(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_tofloat);
+PG_FUNCTION_INFO_V1(agtype_tofloat);
 
-Datum age_tofloat(PG_FUNCTION_ARGS)
+Datum agtype_tofloat(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -4767,9 +4767,9 @@ Datum age_tofloat(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_tointeger);
+PG_FUNCTION_INFO_V1(agtype_tointeger);
 
-Datum age_tointeger(PG_FUNCTION_ARGS)
+Datum agtype_tointeger(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -4961,9 +4961,9 @@ Datum age_tointeger(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_size);
+PG_FUNCTION_INFO_V1(agtype_size);
 
-Datum age_size(PG_FUNCTION_ARGS)
+Datum agtype_size(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -5062,9 +5062,9 @@ Datum agtype_to_graphid(PG_FUNCTION_ARGS)
     PG_RETURN_INT16(agtv.val.int_value);
 }
 
-PG_FUNCTION_INFO_V1(age_type);
+PG_FUNCTION_INFO_V1(agtype_type);
 
-Datum age_type(PG_FUNCTION_ARGS)
+Datum agtype_type(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_object = NULL;
@@ -5100,11 +5100,11 @@ Datum age_type(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_label);
+PG_FUNCTION_INFO_V1(agtype_label);
 /*
  * Executor function for label(edge/vertex).
  */
-Datum age_label(PG_FUNCTION_ARGS)
+Datum agtype_label(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_value = NULL;
@@ -5144,9 +5144,9 @@ Datum age_label(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(label));
 }
 
-PG_FUNCTION_INFO_V1(age_tostring);
+PG_FUNCTION_INFO_V1(agtype_tostring);
 
-Datum age_tostring(PG_FUNCTION_ARGS)
+Datum agtype_tostring(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -5290,9 +5290,9 @@ static agtype_iterator *get_next_list_element(agtype_iterator *it,
     return it;
 }
 
-PG_FUNCTION_INFO_V1(age_reverse);
+PG_FUNCTION_INFO_V1(agtype_reverse);
 
-Datum age_reverse(PG_FUNCTION_ARGS)
+Datum agtype_reverse(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -5416,9 +5416,9 @@ Datum age_reverse(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_toupper);
+PG_FUNCTION_INFO_V1(agtype_toupper);
 
-Datum age_toupper(PG_FUNCTION_ARGS)
+Datum agtype_toupper(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -5506,9 +5506,9 @@ Datum age_toupper(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_tolower);
+PG_FUNCTION_INFO_V1(agtype_tolower);
 
-Datum age_tolower(PG_FUNCTION_ARGS)
+Datum agtype_tolower(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -5596,9 +5596,9 @@ Datum age_tolower(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_rtrim);
+PG_FUNCTION_INFO_V1(agtype_rtrim);
 
-Datum age_rtrim(PG_FUNCTION_ARGS)
+Datum agtype_rtrim(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -5687,9 +5687,9 @@ Datum age_rtrim(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_ltrim);
+PG_FUNCTION_INFO_V1(agtype_ltrim);
 
-Datum age_ltrim(PG_FUNCTION_ARGS)
+Datum agtype_ltrim(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -5778,9 +5778,9 @@ Datum age_ltrim(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_trim);
+PG_FUNCTION_INFO_V1(agtype_trim);
 
-Datum age_trim(PG_FUNCTION_ARGS)
+Datum agtype_trim(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -5869,9 +5869,9 @@ Datum age_trim(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_right);
+PG_FUNCTION_INFO_V1(agtype_right);
 
-Datum age_right(PG_FUNCTION_ARGS)
+Datum agtype_right(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -6010,9 +6010,9 @@ Datum age_right(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_left);
+PG_FUNCTION_INFO_V1(agtype_left);
 
-Datum age_left(PG_FUNCTION_ARGS)
+Datum agtype_left(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -6151,9 +6151,9 @@ Datum age_left(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_substring);
+PG_FUNCTION_INFO_V1(agtype_substring);
 
-Datum age_substring(PG_FUNCTION_ARGS)
+Datum agtype_substring(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -6320,9 +6320,9 @@ Datum age_substring(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_split);
+PG_FUNCTION_INFO_V1(agtype_split);
 
-Datum age_split(PG_FUNCTION_ARGS)
+Datum agtype_split(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -6468,9 +6468,9 @@ Datum age_split(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_replace);
+PG_FUNCTION_INFO_V1(agtype_replace);
 
-Datum age_replace(PG_FUNCTION_ARGS)
+Datum agtype_replace(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -6774,9 +6774,9 @@ static Numeric get_numeric_compatible_arg(Datum arg, Oid type, char *funcname,
     return result;
 }
 
-PG_FUNCTION_INFO_V1(age_sin);
+PG_FUNCTION_INFO_V1(agtype_sin);
 
-Datum age_sin(PG_FUNCTION_ARGS)
+Datum agtype_sin(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -6821,9 +6821,9 @@ Datum age_sin(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_cos);
+PG_FUNCTION_INFO_V1(agtype_cos);
 
-Datum age_cos(PG_FUNCTION_ARGS)
+Datum agtype_cos(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -6868,9 +6868,9 @@ Datum age_cos(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_tan);
+PG_FUNCTION_INFO_V1(agtype_tan);
 
-Datum age_tan(PG_FUNCTION_ARGS)
+Datum agtype_tan(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -6915,9 +6915,9 @@ Datum age_tan(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_cot);
+PG_FUNCTION_INFO_V1(agtype_cot);
 
-Datum age_cot(PG_FUNCTION_ARGS)
+Datum agtype_cot(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -6962,9 +6962,9 @@ Datum age_cot(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_asin);
+PG_FUNCTION_INFO_V1(agtype_asin);
 
-Datum age_asin(PG_FUNCTION_ARGS)
+Datum agtype_asin(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7013,9 +7013,9 @@ Datum age_asin(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_acos);
+PG_FUNCTION_INFO_V1(agtype_acos);
 
-Datum age_acos(PG_FUNCTION_ARGS)
+Datum agtype_acos(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7064,9 +7064,9 @@ Datum age_acos(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_atan);
+PG_FUNCTION_INFO_V1(agtype_atan);
 
-Datum age_atan(PG_FUNCTION_ARGS)
+Datum agtype_atan(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7111,9 +7111,9 @@ Datum age_atan(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_atan2);
+PG_FUNCTION_INFO_V1(agtype_atan2);
 
-Datum age_atan2(PG_FUNCTION_ARGS)
+Datum agtype_atan2(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7165,9 +7165,9 @@ Datum age_atan2(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_degrees);
+PG_FUNCTION_INFO_V1(agtype_degrees);
 
-Datum age_degrees(PG_FUNCTION_ARGS)
+Datum agtype_degrees(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7212,9 +7212,9 @@ Datum age_degrees(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_radians);
+PG_FUNCTION_INFO_V1(agtype_radians);
 
-Datum age_radians(PG_FUNCTION_ARGS)
+Datum agtype_radians(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7260,9 +7260,9 @@ Datum age_radians(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_round);
+PG_FUNCTION_INFO_V1(agtype_round);
 
-Datum age_round(PG_FUNCTION_ARGS)
+Datum agtype_round(PG_FUNCTION_ARGS)
 {
     Datum *args = NULL;
     bool *nulls = NULL;
@@ -7341,9 +7341,9 @@ Datum age_round(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_ceil);
+PG_FUNCTION_INFO_V1(agtype_ceil);
 
-Datum age_ceil(PG_FUNCTION_ARGS)
+Datum agtype_ceil(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7390,9 +7390,9 @@ Datum age_ceil(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_floor);
+PG_FUNCTION_INFO_V1(agtype_floor);
 
-Datum age_floor(PG_FUNCTION_ARGS)
+Datum agtype_floor(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7440,9 +7440,9 @@ Datum age_floor(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_abs);
+PG_FUNCTION_INFO_V1(agtype_abs);
 
-Datum age_abs(PG_FUNCTION_ARGS)
+Datum agtype_abs(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7513,9 +7513,9 @@ Datum age_abs(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_sign);
+PG_FUNCTION_INFO_V1(agtype_sign);
 
-Datum age_sign(PG_FUNCTION_ARGS)
+Datum agtype_sign(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7563,9 +7563,9 @@ Datum age_sign(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_log);
+PG_FUNCTION_INFO_V1(agtype_log);
 
-Datum age_log(PG_FUNCTION_ARGS)
+Datum agtype_log(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7624,9 +7624,9 @@ Datum age_log(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_log10);
+PG_FUNCTION_INFO_V1(agtype_log10);
 
-Datum age_log10(PG_FUNCTION_ARGS)
+Datum agtype_log10(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7690,9 +7690,9 @@ Datum age_log10(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_e);
+PG_FUNCTION_INFO_V1(agtype_e);
 
-Datum age_e(PG_FUNCTION_ARGS)
+Datum agtype_e(PG_FUNCTION_ARGS)
 {
     agtype_value agtv_result;
     float8 float_result;
@@ -7707,9 +7707,9 @@ Datum age_e(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_exp);
+PG_FUNCTION_INFO_V1(agtype_exp);
 
-Datum age_exp(PG_FUNCTION_ARGS)
+Datum agtype_exp(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7756,9 +7756,9 @@ Datum age_exp(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_sqrt);
+PG_FUNCTION_INFO_V1(agtype_sqrt);
 
-Datum age_sqrt(PG_FUNCTION_ARGS)
+Datum agtype_sqrt(PG_FUNCTION_ARGS)
 {
     int nargs;
     Datum *args;
@@ -7817,9 +7817,9 @@ Datum age_sqrt(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_timestamp);
+PG_FUNCTION_INFO_V1(agtype_timestamp);
 
-Datum age_timestamp(PG_FUNCTION_ARGS)
+Datum agtype_timestamp(PG_FUNCTION_ARGS)
 {
     agtype_value agtv_result;
     struct timespec ts;
@@ -7836,8 +7836,8 @@ Datum age_timestamp(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_pi);
-Datum age_pi(PG_FUNCTION_ARGS)
+PG_FUNCTION_INFO_V1(agtype_pi);
+Datum agtype_pi(PG_FUNCTION_ARGS)
 {
     agtype_value agtv = {
         .type = AGTV_FLOAT,
@@ -7847,8 +7847,8 @@ Datum age_pi(PG_FUNCTION_ARGS)
     AG_RETURN_AGTYPE_P(agtype_value_to_agtype(&agtv));
 }
 
-PG_FUNCTION_INFO_V1(age_rand);
-Datum age_rand(PG_FUNCTION_ARGS)
+PG_FUNCTION_INFO_V1(agtype_rand);
+Datum agtype_rand(PG_FUNCTION_ARGS)
 {
     agtype_value agtv = {
         .type = AGTV_FLOAT,
@@ -8124,9 +8124,9 @@ agtype *get_one_agtype_from_variadic_args(FunctionCallInfo fcinfo,
  * Note: The sql definition is STRICT so no input NULLs need to
  * be dealt with except for agtype.
  */
-PG_FUNCTION_INFO_V1(age_agtype_sum);
+PG_FUNCTION_INFO_V1(agtype_agtype_sum);
 
-Datum age_agtype_sum(PG_FUNCTION_ARGS)
+Datum agtype_agtype_sum(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg0 = AG_GET_ARG_AGTYPE_P(0);
     agtype *agt_arg1 = AG_GET_ARG_AGTYPE_P(1);
@@ -8281,12 +8281,10 @@ Datum age_agtype_sum(PG_FUNCTION_ARGS)
 
 /*
  * Wrapper function for float8_accum to take an agtype input.
- * This function is defined as STRICT so it does not need to check
- * for NULL input parameters
  */
-PG_FUNCTION_INFO_V1(age_agtype_float8_accum);
+PG_FUNCTION_INFO_V1(agtype_agtype_float8_accum);
 
-Datum age_agtype_float8_accum(PG_FUNCTION_ARGS)
+Datum agtype_agtype_float8_accum(PG_FUNCTION_ARGS)
 {
     Datum dfloat;
     Datum result;
@@ -8300,9 +8298,9 @@ Datum age_agtype_float8_accum(PG_FUNCTION_ARGS)
 }
 
 /* Wrapper for stdDev function. */
-PG_FUNCTION_INFO_V1(age_float8_stddev_samp_aggfinalfn);
+PG_FUNCTION_INFO_V1(agtype_float8_stddev_samp_aggfinalfn);
 
-Datum age_float8_stddev_samp_aggfinalfn(PG_FUNCTION_ARGS)
+Datum agtype_float8_stddev_samp_aggfinalfn(PG_FUNCTION_ARGS)
 {
     Datum result;
     PGFunction func;
@@ -8332,9 +8330,9 @@ Datum age_float8_stddev_samp_aggfinalfn(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_float));
 }
 
-PG_FUNCTION_INFO_V1(age_float8_stddev_pop_aggfinalfn);
+PG_FUNCTION_INFO_V1(agtype_float8_stddev_pop_aggfinalfn);
 
-Datum age_float8_stddev_pop_aggfinalfn(PG_FUNCTION_ARGS)
+Datum agtype_float8_stddev_pop_aggfinalfn(PG_FUNCTION_ARGS)
 {
     Datum result;
     PGFunction func;
@@ -8364,9 +8362,9 @@ Datum age_float8_stddev_pop_aggfinalfn(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(&agtv_float));
 }
 
-PG_FUNCTION_INFO_V1(age_agtype_larger_aggtransfn);
+PG_FUNCTION_INFO_V1(agtype_agtype_larger_aggtransfn);
 
-Datum age_agtype_larger_aggtransfn(PG_FUNCTION_ARGS)
+Datum agtype_agtype_larger_aggtransfn(PG_FUNCTION_ARGS)
 {
     agtype *agtype_arg1;
     agtype *agtype_arg2;
@@ -8396,9 +8394,9 @@ Datum age_agtype_larger_aggtransfn(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_larger);
 }
 
-PG_FUNCTION_INFO_V1(age_agtype_smaller_aggtransfn);
+PG_FUNCTION_INFO_V1(agtype_agtype_smaller_aggtransfn);
 
-Datum age_agtype_smaller_aggtransfn(PG_FUNCTION_ARGS)
+Datum agtype_agtype_smaller_aggtransfn(PG_FUNCTION_ARGS)
 {
     agtype *agtype_arg1 = NULL;
     agtype *agtype_arg2 = NULL;
@@ -8438,9 +8436,9 @@ static Datum float8_lerp(Datum lo, Datum hi, double pct)
 }
 
 /* Code borrowed and adjusted from PG's ordered_set_transition function */
-PG_FUNCTION_INFO_V1(age_percentile_aggtransfn);
+PG_FUNCTION_INFO_V1(agtype_percentile_aggtransfn);
 
-Datum age_percentile_aggtransfn(PG_FUNCTION_ARGS)
+Datum agtype_percentile_aggtransfn(PG_FUNCTION_ARGS)
 {
     PercentileGroupAggState *pgastate;
 
@@ -8504,9 +8502,9 @@ Datum age_percentile_aggtransfn(PG_FUNCTION_ARGS)
 }
 
 /* Code borrowed and adjusted from PG's percentile_cont_final function */
-PG_FUNCTION_INFO_V1(age_percentile_cont_aggfinalfn);
+PG_FUNCTION_INFO_V1(agtype_percentile_cont_aggfinalfn);
 
-Datum age_percentile_cont_aggfinalfn(PG_FUNCTION_ARGS)
+Datum agtype_percentile_cont_aggfinalfn(PG_FUNCTION_ARGS)
 {
     PercentileGroupAggState *pgastate;
     float8 percentile;
@@ -8581,9 +8579,9 @@ Datum age_percentile_cont_aggfinalfn(PG_FUNCTION_ARGS)
 }
 
 /* Code borrowed and adjusted from PG's percentile_disc_final function */
-PG_FUNCTION_INFO_V1(age_percentile_disc_aggfinalfn);
+PG_FUNCTION_INFO_V1(agtype_percentile_disc_aggfinalfn);
 
-Datum age_percentile_disc_aggfinalfn(PG_FUNCTION_ARGS)
+Datum agtype_percentile_disc_aggfinalfn(PG_FUNCTION_ARGS)
 {
     PercentileGroupAggState *pgastate;
     double percentile;
@@ -8644,9 +8642,9 @@ Datum age_percentile_disc_aggfinalfn(PG_FUNCTION_ARGS)
 }
 
 /* functions to support the aggregate function COLLECT() */
-PG_FUNCTION_INFO_V1(age_collect_aggtransfn);
+PG_FUNCTION_INFO_V1(agtype_collect_aggtransfn);
 
-Datum age_collect_aggtransfn(PG_FUNCTION_ARGS)
+Datum agtype_collect_aggtransfn(PG_FUNCTION_ARGS)
 {
     agtype_in_state *castate;
     int nargs;
@@ -8734,9 +8732,9 @@ Datum age_collect_aggtransfn(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(castate);
 }
 
-PG_FUNCTION_INFO_V1(age_collect_aggfinalfn);
+PG_FUNCTION_INFO_V1(agtype_collect_aggfinalfn);
 
-Datum age_collect_aggfinalfn(PG_FUNCTION_ARGS)
+Datum agtype_collect_aggfinalfn(PG_FUNCTION_ARGS)
 {
     agtype_in_state *castate;
     MemoryContext old_mcxt;
@@ -8918,14 +8916,14 @@ agtype_value *get_agtype_value(char *funcname, agtype *agt_arg,
     return agtv_value;
 }
 
-PG_FUNCTION_INFO_V1(age_eq_tilde);
+PG_FUNCTION_INFO_V1(agtype_eq_tilde);
 /*
  * Execution function for =~ aka regular expression comparisons
  *
  * Note: Everything must resolve to 2 agtype strings. All others types are
  * errors.
  */
-Datum age_eq_tilde(PG_FUNCTION_ARGS)
+Datum agtype_eq_tilde(PG_FUNCTION_ARGS)
 {
     agtype *agt_string = NULL;
     agtype *agt_pattern = NULL;
@@ -9039,11 +9037,11 @@ static agtype_iterator *get_next_object_key(agtype_iterator *it,
     return it;
 }
 
-PG_FUNCTION_INFO_V1(age_keys);
+PG_FUNCTION_INFO_V1(agtype_keys);
 /*
  * Execution function to implement openCypher keys() function
  */
-Datum age_keys(PG_FUNCTION_ARGS)
+Datum agtype_keys(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_result = NULL;
@@ -9115,11 +9113,11 @@ Datum age_keys(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(agtv_result));
 }
 
-PG_FUNCTION_INFO_V1(age_nodes);
+PG_FUNCTION_INFO_V1(agtype_nodes);
 /*
  * Execution function to implement openCypher nodes() function
  */
-Datum age_nodes(PG_FUNCTION_ARGS)
+Datum agtype_nodes(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_path = NULL;
@@ -9176,7 +9174,7 @@ Datum age_nodes(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(agis_result.res));
 }
 
-PG_FUNCTION_INFO_V1(age_labels);
+PG_FUNCTION_INFO_V1(agtype_labels);
 /*
  * Execution function to implement openCypher labels() function
  *
@@ -9185,7 +9183,7 @@ PG_FUNCTION_INFO_V1(age_labels);
  * This function is defined to return NULL on NULL input. So, no need to check
  * for SQL NULL input.
  */
-Datum age_labels(PG_FUNCTION_ARGS)
+Datum agtype_labels(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_temp = NULL;
@@ -9245,11 +9243,11 @@ Datum age_labels(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(agis_result.res));
 }
 
-PG_FUNCTION_INFO_V1(age_relationships);
+PG_FUNCTION_INFO_V1(agtype_relationships);
 /*
  * Execution function to implement openCypher relationships() function
  */
-Datum age_relationships(PG_FUNCTION_ARGS)
+Datum agtype_relationships(PG_FUNCTION_ARGS)
 {
     agtype *agt_arg = NULL;
     agtype_value *agtv_path = NULL;
@@ -9380,11 +9378,11 @@ static int64 get_int64_from_int_datums(Datum d, Oid type, char *funcname,
     return result;
 }
 
-PG_FUNCTION_INFO_V1(age_range);
+PG_FUNCTION_INFO_V1(agtype_range);
 /*
  * Execution function to implement openCypher range() function
  */
-Datum age_range(PG_FUNCTION_ARGS)
+Datum agtype_range(PG_FUNCTION_ARGS)
 {
     Datum *args = NULL;
     bool *nulls = NULL;
@@ -9485,14 +9483,14 @@ Datum age_range(PG_FUNCTION_ARGS)
     PG_RETURN_POINTER(agtype_value_to_agtype(agis_result.res));
 }
 
-PG_FUNCTION_INFO_V1(age_unnest);
+PG_FUNCTION_INFO_V1(agtype_unnest);
 /*
  * Function to convert the Array type of Agtype into each row. It is used for
  * Cypher `UNWIND` clause, but considering the situation in which the user can
  * directly use this function in vanilla PGSQL, put a second parameter related
  * to this.
  */
-Datum age_unnest(PG_FUNCTION_ARGS)
+Datum agtype_unnest(PG_FUNCTION_ARGS)
 {
     agtype *agtype_arg = AG_GET_ARG_AGTYPE_P(0);
     bool block_types = PG_GETARG_BOOL(1);

--- a/src/include/commands/label_commands.h
+++ b/src/include/commands/label_commands.h
@@ -31,20 +31,20 @@
 #define AG_VERTEX_COLNAME_ID "id"
 #define AG_VERTEX_COLNAME_PROPERTIES "properties"
 
-#define AG_ACCESS_FUNCTION_ID "age_id"
+#define AG_ACCESS_FUNCTION_ID "id"
 
-#define AG_VERTEX_ACCESS_FUNCTION_ID "age_id"
-#define AG_VERTEX_ACCESS_FUNCTION_PROPERTIES "age_properties"
+#define AG_VERTEX_ACCESS_FUNCTION_ID "id"
+#define AG_VERTEX_ACCESS_FUNCTION_PROPERTIES "properties"
 
 #define AG_EDGE_COLNAME_ID "id"
 #define AG_EDGE_COLNAME_START_ID "start_id"
 #define AG_EDGE_COLNAME_END_ID "end_id"
 #define AG_EDGE_COLNAME_PROPERTIES "properties"
 
-#define AG_EDGE_ACCESS_FUNCTION_ID "age_id"
-#define AG_EDGE_ACCESS_FUNCTION_START_ID "age_start_id"
-#define AG_EDGE_ACCESS_FUNCTION_END_ID "age_end_id"
-#define AG_EDGE_ACCESS_FUNCTION_PROPERTIES "age_properties"
+#define AG_EDGE_ACCESS_FUNCTION_ID "id"
+#define AG_EDGE_ACCESS_FUNCTION_START_ID "start_id"
+#define AG_EDGE_ACCESS_FUNCTION_END_ID "end_id"
+#define AG_EDGE_ACCESS_FUNCTION_PROPERTIES "properties"
 
 #define IS_DEFAULT_LABEL_EDGE(str) \
     (str != NULL && strcmp(AG_DEFAULT_LABEL_EDGE, str) == 0)


### PR DESCRIPTION
Removed the 'age_' from the start of function names, this will make error messages more clear. Also conforms to Postgres conventions for linking sql function names to the c function that implements that function.

the c code functions had the 'age_' replace with 'agtype_' because these functions are for the agtype type and this follows the jsonb implementation that we are building on top of.

Fixed a bug where startnode and endnode had to be input in camelCase only to work in a cypher function.