### PR TITLE
[ Support Date/time datatypes ] Add support for other datatypes for to_timestamp function

### DIFF
--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -1944,6 +1944,30 @@ $$) AS r(result agtype);
  Wed Dec 17 07:37:16 1997
 (1 row)
 
+SELECT * FROM cypher('expr', $$
+RETURN 70.0::timestamp
+$$) AS r(result agtype);
+          result          
+--------------------------
+ Sat Jan 01 00:01:10 2000
+(1 row)
+
+SELECT * FROM cypher('expr', $$
+RETURN 70::timestamp
+$$) AS r(result agtype);
+          result          
+--------------------------
+ Sat Jan 01 00:01:10 2000
+(1 row)
+
+SELECT * FROM cypher('expr', $$
+RETURN '1997-12-17'::date::timestamp
+$$) AS r(result agtype);
+          result          
+--------------------------
+ Wed Dec 17 00:00:00 1997
+(1 row)
+
 --
 -- timestamptz
 --

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -876,6 +876,15 @@ $$) AS r(result agtype);
 SELECT * FROM cypher('expr', $$
 RETURN 'Wed Dec 17 07:37:16 1997'::timestamp
 $$) AS r(result agtype);
+SELECT * FROM cypher('expr', $$
+RETURN 70.0::timestamp
+$$) AS r(result agtype);
+SELECT * FROM cypher('expr', $$
+RETURN 70::timestamp
+$$) AS r(result agtype);
+SELECT * FROM cypher('expr', $$
+RETURN '1997-12-17'::date::timestamp
+$$) AS r(result agtype);
 
 --
 -- timestamptz


### PR DESCRIPTION
Added support for types int, float and date in function agtype_typecast_timestamp which only supported string before.
Also added regression tests.

This resolves the issue https://github.com/AGEDB-INC/agedb-community/issues/35