### PR TITLE
[ Support Date/time datatypes ] Add support for other datatypes for to_timestamptz function

### DIFF
--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -1995,6 +1995,30 @@ $$) AS r(result agtype);
  Tue Dec 16 22:37:16 1997 GMT
 (1 row)
 
+SELECT * FROM cypher('expr', $$
+RETURN 70.0::timestamptz
+$$) AS r(result agtype);
+            result            
+------------------------------
+ Sat Jan 01 00:01:10 2000 GMT
+(1 row)
+
+SELECT * FROM cypher('expr', $$
+RETURN 70::timestamptz
+$$) AS r(result agtype);
+            result            
+------------------------------
+ Sat Jan 01 00:01:10 2000 GMT
+(1 row)
+
+SELECT * FROM cypher('expr', $$
+RETURN '1997-12-17'::date::timestamptz
+$$) AS r(result agtype);
+            result            
+------------------------------
+ Wed Dec 17 00:00:00 1997 GMT
+(1 row)
+
 --
 -- date
 --  

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -898,7 +898,15 @@ $$) AS r(result agtype);
 SELECT * FROM cypher('expr', $$
 RETURN 'Wed Dec 17 07:37:16 1997+09'::timestamptz
 $$) AS r(result agtype);
-
+SELECT * FROM cypher('expr', $$
+RETURN 70.0::timestamptz
+$$) AS r(result agtype);
+SELECT * FROM cypher('expr', $$
+RETURN 70::timestamptz
+$$) AS r(result agtype);
+SELECT * FROM cypher('expr', $$
+RETURN '1997-12-17'::date::timestamptz
+$$) AS r(result agtype);
 
 --
 -- date


### PR DESCRIPTION
Added support for types int, float and date in function agtype_typecast_timestamptz which only supported string before.
Also added regression tests.

This resolves the issue https://github.com/AGEDB-INC/postgraph/issues/36