### PR TITLE
[ Support Date/time datatypes ] Add support for other datatypes for to_time function

### DIFF
--- a/regress/expected/expr.out
+++ b/regress/expected/expr.out
@@ -2049,6 +2049,30 @@ $$) AS r(result agtype);
  07:37:16
 (1 row)
 
+SELECT * FROM cypher('expr', $$
+RETURN 70::time
+$$) AS r(result agtype);
+  result  
+----------
+ 00:01:10
+(1 row)
+
+SELECT * FROM cypher('expr', $$
+RETURN 70.0::time
+$$) AS r(result agtype);
+  result  
+----------
+ 00:01:10
+(1 row)
+
+SELECT * FROM cypher('expr', $$
+RETURN '1997-12-17'::date::time
+$$) AS r(result agtype);
+      result      
+------------------
+ 4294949416:00:00
+(1 row)
+
 --
 -- timetz
 --

--- a/regress/sql/expr.sql
+++ b/regress/sql/expr.sql
@@ -925,7 +925,15 @@ $$) AS r(result agtype);
 SELECT * FROM cypher('expr', $$
 RETURN '07:37:16'::time
 $$) AS r(result agtype);
-
+SELECT * FROM cypher('expr', $$
+RETURN 70::time
+$$) AS r(result agtype);
+SELECT * FROM cypher('expr', $$
+RETURN 70.0::time
+$$) AS r(result agtype);
+SELECT * FROM cypher('expr', $$
+RETURN '1997-12-17'::date::time
+$$) AS r(result agtype);
 --
 -- timetz
 --

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -4361,7 +4361,6 @@ Datum agtype_typecast_time(PG_FUNCTION_ARGS)
     if (agtv->type == AGTV_TIMESTAMP)
         AG_RETURN_AGTYPE_P(agt);
         
-    // Assuming float value represent unix timestamp in seconds.
     if (agtv->type == AGTV_FLOAT) 
     {
         double num = agtv->val.float_value;
@@ -4371,7 +4370,6 @@ Datum agtype_typecast_time(PG_FUNCTION_ARGS)
         PG_RETURN_POINTER(agtype_value_to_agtype(agtv));
     }
 
-    // Assuming int value represent unix timestamp in seconds.
     if (agtv->type == AGTV_INTEGER) 
     {
         int64 num = agtv->val.int_value;

--- a/src/backend/utils/adt/agtype.c
+++ b/src/backend/utils/adt/agtype.c
@@ -4356,12 +4356,51 @@ Datum agtype_typecast_time(PG_FUNCTION_ARGS)
     Timestamp t;
         
     if (agtv->type == AGTV_NULL)
-        PG_RETURN_NULL();
-    
+        PG_RETURN_NULL();    
     
     if (agtv->type == AGTV_TIMESTAMP)
         AG_RETURN_AGTYPE_P(agt);
         
+    // Assuming float value represent unix timestamp in seconds.
+    if (agtv->type == AGTV_FLOAT) 
+    {
+        double num = agtv->val.float_value;
+        t = (Timestamp) (num * USECS_PER_SEC);
+        agtv->type = AGTV_TIME;
+        agtv->val.int_value = (int64) t;
+        PG_RETURN_POINTER(agtype_value_to_agtype(agtv));
+    }
+
+    // Assuming int value represent unix timestamp in seconds.
+    if (agtv->type == AGTV_INTEGER) 
+    {
+        int64 num = agtv->val.int_value;
+        t = (Timestamp) (num * USECS_PER_SEC);
+        agtv->type = AGTV_TIME;
+        agtv->val.int_value = (int64) t;
+        PG_RETURN_POINTER(agtype_value_to_agtype(agtv));
+    }
+
+    // Converting date type to timestamp.
+    if (agtv->type == AGTV_DATE) {
+        DateADT date = DatumGetDateADT(agtv->val.int_value);
+        Timestamp timestamp;
+
+        if (DATE_NOT_FINITE(date)) {
+            ereport(ERROR,
+                    (errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+                    errmsg("date out of range: \"%s\"",
+                            DatumGetCString(DirectFunctionCall1(date_out, DateADTGetDatum(date))))));
+        }
+
+        timestamp = DatumGetTimestamp(DirectFunctionCall1(date_timestamp, DateADTGetDatum(date)));
+
+        agtv->type = AGTV_TIME;
+        agtv->val.int_value = (int64) timestamp;
+
+        PG_RETURN_POINTER(agtype_value_to_agtype(agtv));
+    }
+
     if (agtv->type != AGTV_STRING)
         ereport(ERROR,
                 (errcode(ERRCODE_INVALID_PARAMETER_VALUE),


### PR DESCRIPTION
Added support for types int, float and date in function agtype_typecast_time which only supported string before.
Also added regression tests.

This resolves the issue https://github.com/AGEDB-INC/postgraph/issues/37