### PR TITLE
[Graph Generation Algorithms] Add properties support on create_complete_graph

### DIFF
--- a/age--1.2.0.sql
+++ b/age--1.2.0.sql
@@ -4167,7 +4167,13 @@ STABLE
 PARALLEL SAFE
 AS 'MODULE_PATHNAME';
 
-CREATE FUNCTION ag_catalog.create_complete_graph(graph_name name, nodes int, edge_label name, node_label name = NULL)
+CREATE FUNCTION ag_catalog.create_complete_graph(
+    graph_name name, 
+    number_of_nodes int, 
+    edge_label name, 
+    edge_properties agtype = NULL,
+    node_label name = NULL,
+    node_properties agtype = NULL)
 RETURNS void
 LANGUAGE c
 CALLED ON NULL INPUT

--- a/regress/expected/graph_generation.out
+++ b/regress/expected/graph_generation.out
@@ -18,7 +18,11 @@
  */
 LOAD 'age';
 SET search_path = ag_catalog;
-SELECT * FROM create_complete_graph('gp1',5,'edges','vertices');
+-- TESTS FOR COMPLETE GRAPH GENERATION
+SELECT * FROM create_complete_graph(
+    'gp1', 5,
+    'edges', '{"edge_property":"test"}'::agtype,
+    'vertices', '{"node_property":"test"}'::agtype);
 NOTICE:  graph "gp1" has been created
 NOTICE:  VLabel "vertices" has been created
 NOTICE:  ELabel "edges" has been created
@@ -39,22 +43,35 @@ SELECT COUNT(*) FROM gp1."vertices";
      5
 (1 row)
 
-SELECT * FROM cypher('gp1', $$MATCH (a)-[e]->(b) RETURN e$$) as (n agtype);
-                                                             n                                                              
-----------------------------------------------------------------------------------------------------------------------------
- {"id": 1125899906842625, "label": "edges", "end_id": 844424930131970, "start_id": 844424930131969, "properties": {}}::edge
- {"id": 1125899906842629, "label": "edges", "end_id": 844424930131971, "start_id": 844424930131970, "properties": {}}::edge
- {"id": 1125899906842626, "label": "edges", "end_id": 844424930131971, "start_id": 844424930131969, "properties": {}}::edge
- {"id": 1125899906842630, "label": "edges", "end_id": 844424930131972, "start_id": 844424930131970, "properties": {}}::edge
- {"id": 1125899906842627, "label": "edges", "end_id": 844424930131972, "start_id": 844424930131969, "properties": {}}::edge
- {"id": 1125899906842632, "label": "edges", "end_id": 844424930131972, "start_id": 844424930131971, "properties": {}}::edge
- {"id": 1125899906842631, "label": "edges", "end_id": 844424930131973, "start_id": 844424930131970, "properties": {}}::edge
- {"id": 1125899906842634, "label": "edges", "end_id": 844424930131973, "start_id": 844424930131972, "properties": {}}::edge
- {"id": 1125899906842633, "label": "edges", "end_id": 844424930131973, "start_id": 844424930131971, "properties": {}}::edge
- {"id": 1125899906842628, "label": "edges", "end_id": 844424930131973, "start_id": 844424930131969, "properties": {}}::edge
+SELECT * FROM cypher('gp1', $$MATCH (a) RETURN a$$) as (vertexes agtype);
+                                           vertexes                                            
+-----------------------------------------------------------------------------------------------
+ {"id": 844424930131969, "label": "vertices", "properties": {"node_property": "test"}}::vertex
+ {"id": 844424930131970, "label": "vertices", "properties": {"node_property": "test"}}::vertex
+ {"id": 844424930131971, "label": "vertices", "properties": {"node_property": "test"}}::vertex
+ {"id": 844424930131972, "label": "vertices", "properties": {"node_property": "test"}}::vertex
+ {"id": 844424930131973, "label": "vertices", "properties": {"node_property": "test"}}::vertex
+(5 rows)
+
+SELECT * FROM cypher('gp1', $$MATCH (a)-[e]->(b) RETURN e$$) as (edges agtype);
+                                                                       edges                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ {"id": 1125899906842625, "label": "edges", "end_id": 844424930131970, "start_id": 844424930131969, "properties": {"edge_property": "test"}}::edge
+ {"id": 1125899906842629, "label": "edges", "end_id": 844424930131971, "start_id": 844424930131970, "properties": {"edge_property": "test"}}::edge
+ {"id": 1125899906842626, "label": "edges", "end_id": 844424930131971, "start_id": 844424930131969, "properties": {"edge_property": "test"}}::edge
+ {"id": 1125899906842630, "label": "edges", "end_id": 844424930131972, "start_id": 844424930131970, "properties": {"edge_property": "test"}}::edge
+ {"id": 1125899906842627, "label": "edges", "end_id": 844424930131972, "start_id": 844424930131969, "properties": {"edge_property": "test"}}::edge
+ {"id": 1125899906842632, "label": "edges", "end_id": 844424930131972, "start_id": 844424930131971, "properties": {"edge_property": "test"}}::edge
+ {"id": 1125899906842631, "label": "edges", "end_id": 844424930131973, "start_id": 844424930131970, "properties": {"edge_property": "test"}}::edge
+ {"id": 1125899906842634, "label": "edges", "end_id": 844424930131973, "start_id": 844424930131972, "properties": {"edge_property": "test"}}::edge
+ {"id": 1125899906842633, "label": "edges", "end_id": 844424930131973, "start_id": 844424930131971, "properties": {"edge_property": "test"}}::edge
+ {"id": 1125899906842628, "label": "edges", "end_id": 844424930131973, "start_id": 844424930131969, "properties": {"edge_property": "test"}}::edge
 (10 rows)
 
-SELECT * FROM create_complete_graph('gp1',5,'edges','vertices');
+SELECT * FROM create_complete_graph(
+    'gp1', 5,
+    'edges', '{"type":"edge","connection":"strong"}'::agtype,
+    'vertices', '{"type":"node"}'::agtype);
  create_complete_graph 
 -----------------------
  
@@ -72,20 +89,41 @@ SELECT COUNT(*) FROM gp1."vertices";
     10
 (1 row)
 
-SELECT * FROM create_complete_graph('gp2',5,'edges');
+SELECT * FROM create_complete_graph(
+    'gp2',7,
+    'edges', '{"type":"edge"}'::agtype,
+    'vertices', '{"type":"node"}'::agtype);
 NOTICE:  graph "gp2" has been created
+NOTICE:  VLabel "vertices" has been created
 NOTICE:  ELabel "edges" has been created
  create_complete_graph 
 -----------------------
  
 (1 row)
 
-SELECT * FROM create_complete_graph('gp3',5, NULL);
-ERROR:  edge label can not be NULL
-SELECT * FROM create_complete_graph('gp4',NULL,NULL);
-ERROR:  number of nodes can not be NULL
+-- SHOULD FAIL
+-- NULL graph name
 SELECT * FROM create_complete_graph(NULL,NULL,NULL);
 ERROR:  graph name can not be NULL
+-- NULL number of nodes
+SELECT * FROM create_complete_graph(
+    'gp3',NULL,
+    'edges','{"prop":"any"}'::agtype,
+    'vertices', '{"prop":"any"}'::agtype);
+ERROR:  number of nodes can not be NULL
+-- NULL edge label
+SELECT * FROM create_complete_graph(
+    'gp4',5, 
+    NULL,'{"prop":"any"}'::agtype,
+    'vertices', '{"prop":"any"}'::agtype);
+ERROR:  edge label can not be NULL
+-- Should error out because same labels are used for both vertices and edges
+SELECT * FROM create_complete_graph(
+    'gp5',5,
+    'label','{"edge_prop":"any"}'::agtype,
+    'label','{"node_prop":"any"}'::agtype);
+ERROR:  vertex and edge label cannot be the same
+-- DROPPING GRAPHS
 SELECT drop_graph('gp1', true);
 NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to table gp1._ag_label_vertex
@@ -99,9 +137,10 @@ NOTICE:  graph "gp1" has been dropped
 (1 row)
 
 SELECT drop_graph('gp2', true);
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to table gp2._ag_label_vertex
 drop cascades to table gp2._ag_label_edge
+drop cascades to table gp2.vertices
 drop cascades to table gp2.edges
 NOTICE:  graph "gp2" has been dropped
  drop_graph 

--- a/regress/sql/graph_generation.sql
+++ b/regress/sql/graph_generation.sql
@@ -22,26 +22,57 @@ LOAD 'age';
 
 SET search_path = ag_catalog;
 
-SELECT * FROM create_complete_graph('gp1',5,'edges','vertices');
+-- TESTS FOR COMPLETE GRAPH GENERATION
+
+SELECT * FROM create_complete_graph(
+    'gp1', 5,
+    'edges', '{"edge_property":"test"}'::agtype,
+    'vertices', '{"node_property":"test"}'::agtype);
 
 SELECT COUNT(*) FROM gp1."edges";
 SELECT COUNT(*) FROM gp1."vertices";
 
-SELECT * FROM cypher('gp1', $$MATCH (a)-[e]->(b) RETURN e$$) as (n agtype);
+SELECT * FROM cypher('gp1', $$MATCH (a) RETURN a$$) as (vertexes agtype);
+SELECT * FROM cypher('gp1', $$MATCH (a)-[e]->(b) RETURN e$$) as (edges agtype);
 
-SELECT * FROM create_complete_graph('gp1',5,'edges','vertices');
+SELECT * FROM create_complete_graph(
+    'gp1', 5,
+    'edges', '{"type":"edge","connection":"strong"}'::agtype,
+    'vertices', '{"type":"node"}'::agtype);
 
 SELECT COUNT(*) FROM gp1."edges";
 SELECT COUNT(*) FROM gp1."vertices";
 
-SELECT * FROM create_complete_graph('gp2',5,'edges');
+SELECT * FROM create_complete_graph(
+    'gp2',7,
+    'edges', '{"type":"edge"}'::agtype,
+    'vertices', '{"type":"node"}'::agtype);
 
-SELECT * FROM create_complete_graph('gp3',5, NULL);
 
-SELECT * FROM create_complete_graph('gp4',NULL,NULL);
+-- SHOULD FAIL
 
+-- NULL graph name
 SELECT * FROM create_complete_graph(NULL,NULL,NULL);
 
+-- NULL number of nodes
+SELECT * FROM create_complete_graph(
+    'gp3',NULL,
+    'edges','{"prop":"any"}'::agtype,
+    'vertices', '{"prop":"any"}'::agtype);
+
+-- NULL edge label
+SELECT * FROM create_complete_graph(
+    'gp4',5, 
+    NULL,'{"prop":"any"}'::agtype,
+    'vertices', '{"prop":"any"}'::agtype);
+
+-- Should error out because same labels are used for both vertices and edges
+SELECT * FROM create_complete_graph(
+    'gp5',5,
+    'label','{"edge_prop":"any"}'::agtype,
+    'label','{"node_prop":"any"}'::agtype);
+
+-- DROPPING GRAPHS
 SELECT drop_graph('gp1', true);
 SELECT drop_graph('gp2', true);
 


### PR DESCRIPTION
As seen in the age--1.2.0.sql file, now the create_complete_graph function can be called with properties arguments, so the nodes and edges will have starting properties in common.

This would be beneficial to have an initial structure in common between nodes or edges.

A use case would be on creating a new group with a set of individuals on a social media.
Maybe they could have an initial Status of newcomer in this group, with 0 reputation and Default privacy settings.

In the same line, the connection between them would start with a strength of 1, and if they are best friends as false.

We would start that graph with the command:

```cypher
SELECT create_complete_graph('social_media', 20, 
'group_connection', '{"strength":"1", "best_friends":"true"}',
'that_new_group', '{"Status":"Newcomer", "Reputation":"0", "Privacy_settings":"Default"});
```

So that would serve as a baseline or starting point for all users, making the initialization of the graph more straightforward.